### PR TITLE
clang compatibility fixes

### DIFF
--- a/src/algebra/curves/alt_bn128/alt_bn128_g1.hpp
+++ b/src/algebra/curves/alt_bn128/alt_bn128_g1.hpp
@@ -77,10 +77,10 @@ alt_bn128_G1 operator*(const bigint<m> &lhs, const alt_bn128_G1 &rhs)
     return scalar_mul<alt_bn128_G1, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-alt_bn128_G1 operator*(const Fp_model<m,modulus_p> &lhs, const alt_bn128_G1 &rhs)
+template<typename T>
+alt_bn128_G1 operator*(const T &lhs, const alt_bn128_G1 &rhs)
 {
-    return scalar_mul<alt_bn128_G1, m>(rhs, lhs.as_bigint());
+    return scalar_mul<alt_bn128_G1, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 std::ostream& operator<<(std::ostream& out, const std::vector<alt_bn128_G1> &v);

--- a/src/algebra/curves/alt_bn128/alt_bn128_g2.hpp
+++ b/src/algebra/curves/alt_bn128/alt_bn128_g2.hpp
@@ -81,10 +81,10 @@ alt_bn128_G2 operator*(const bigint<m> &lhs, const alt_bn128_G2 &rhs)
     return scalar_mul<alt_bn128_G2, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-alt_bn128_G2 operator*(const Fp_model<m,modulus_p> &lhs, const alt_bn128_G2 &rhs)
+template<typename T>
+alt_bn128_G2 operator*(const T &lhs, const alt_bn128_G2 &rhs)
 {
-    return scalar_mul<alt_bn128_G2, m>(rhs, lhs.as_bigint());
+    return scalar_mul<alt_bn128_G2, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 template<typename T>

--- a/src/algebra/curves/bn128/bn128_g1.hpp
+++ b/src/algebra/curves/bn128/bn128_g1.hpp
@@ -75,11 +75,11 @@ bn128_G1 operator*(const bigint<m> &lhs, const bn128_G1 &rhs)
 {
     return scalar_mul<bn128_G1, m>(rhs, lhs);
 }
-
-template<mp_size_t m, const bigint<m>& modulus_p>
-bn128_G1 operator*(const Fp_model<m,modulus_p> &lhs, const bn128_G1 &rhs)
+  
+template<typename T>
+bn128_G1 operator*(const T &lhs, const bn128_G1 &rhs)
 {
-    return scalar_mul<bn128_G1, m>(rhs, lhs.as_bigint());
+    return scalar_mul<bn128_G1, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 std::ostream& operator<<(std::ostream& out, const std::vector<bn128_G1> &v);

--- a/src/algebra/curves/bn128/bn128_g2.hpp
+++ b/src/algebra/curves/bn128/bn128_g2.hpp
@@ -77,11 +77,22 @@ bn128_G2 operator*(const bigint<m> &lhs, const bn128_G2 &rhs)
     return scalar_mul<bn128_G2, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-bn128_G2 operator*(const Fp_model<m, modulus_p> &lhs, const bn128_G2 &rhs)
+
+template<typename T>
+bn128_G2 operator*(const T &lhs, const bn128_G2 &rhs)
+{
+    return scalar_mul<bn128_G2, T::num_limbs>(rhs, lhs.as_bigint());
+}
+
+
+
+/*
+template<mp_size_t m>
+bn128_G2 operator*(const Fp_model<m, libff::bn128_modulus_r> &lhs, const bn128_G2 &rhs)
 {
     return scalar_mul<bn128_G2, m>(rhs, lhs.as_bigint());
 }
+*/
 
 template<typename T>
 void batch_to_special_all_non_zeros(std::vector<T> &vec);

--- a/src/algebra/curves/edwards/edwards_g1.hpp
+++ b/src/algebra/curves/edwards/edwards_g1.hpp
@@ -79,10 +79,10 @@ edwards_G1 operator*(const bigint<m> &lhs, const edwards_G1 &rhs)
     return scalar_mul<edwards_G1, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-edwards_G1 operator*(const Fp_model<m,modulus_p> &lhs, const edwards_G1 &rhs)
+template<typename T>
+edwards_G1 operator*(const T &lhs, const edwards_G1 &rhs)
 {
-    return scalar_mul<edwards_G1, m>(rhs, lhs.as_bigint());
+    return scalar_mul<edwards_G1, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 std::ostream& operator<<(std::ostream& out, const std::vector<edwards_G1> &v);

--- a/src/algebra/curves/edwards/edwards_g2.hpp
+++ b/src/algebra/curves/edwards/edwards_g2.hpp
@@ -85,10 +85,10 @@ edwards_G2 operator*(const bigint<m> &lhs, const edwards_G2 &rhs)
     return scalar_mul<edwards_G2, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-edwards_G2 operator*(const Fp_model<m, modulus_p> &lhs, const edwards_G2 &rhs)
+template<typename T>
+edwards_G2 operator*(const T &lhs, const edwards_G2 &rhs)
 {
-   return scalar_mul<edwards_G2, m>(rhs, lhs.as_bigint());
+   return scalar_mul<edwards_G2, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 template<typename T>

--- a/src/algebra/curves/mnt/mnt4/mnt4_g1.hpp
+++ b/src/algebra/curves/mnt/mnt4/mnt4_g1.hpp
@@ -90,10 +90,10 @@ mnt4_G1 operator*(const bigint<m> &lhs, const mnt4_G1 &rhs)
     return scalar_mul<mnt4_G1, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-mnt4_G1 operator*(const Fp_model<m,modulus_p> &lhs, const mnt4_G1 &rhs)
+template<typename T>
+mnt4_G1 operator*(const T &lhs, const mnt4_G1 &rhs)
 {
-    return scalar_mul<mnt4_G1, m>(rhs, lhs.as_bigint());
+    return scalar_mul<mnt4_G1, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 std::ostream& operator<<(std::ostream& out, const std::vector<mnt4_G1> &v);

--- a/src/algebra/curves/mnt/mnt4/mnt4_g2.hpp
+++ b/src/algebra/curves/mnt/mnt4/mnt4_g2.hpp
@@ -95,10 +95,10 @@ mnt4_G2 operator*(const bigint<m> &lhs, const mnt4_G2 &rhs)
     return scalar_mul<mnt4_G2, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-mnt4_G2 operator*(const Fp_model<m,modulus_p> &lhs, const mnt4_G2 &rhs)
+template<typename T>
+mnt4_G2 operator*(const T &lhs, const mnt4_G2 &rhs)
 {
-    return scalar_mul<mnt4_G2, m>(rhs, lhs.as_bigint());
+    return scalar_mul<mnt4_G2, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 template<typename T>

--- a/src/algebra/curves/mnt/mnt6/mnt6_g1.hpp
+++ b/src/algebra/curves/mnt/mnt6/mnt6_g1.hpp
@@ -90,10 +90,10 @@ mnt6_G1 operator*(const bigint<m> &lhs, const mnt6_G1 &rhs)
     return scalar_mul<mnt6_G1, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-mnt6_G1 operator*(const Fp_model<m,modulus_p> &lhs, const mnt6_G1 &rhs)
+template<typename T>
+mnt6_G1 operator*(const T &lhs, const mnt6_G1 &rhs)
 {
-    return scalar_mul<mnt6_G1, m>(rhs, lhs.as_bigint());
+    return scalar_mul<mnt6_G1, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 std::ostream& operator<<(std::ostream& out, const std::vector<mnt6_G1> &v);

--- a/src/algebra/curves/mnt/mnt6/mnt6_g2.hpp
+++ b/src/algebra/curves/mnt/mnt6/mnt6_g2.hpp
@@ -95,10 +95,10 @@ mnt6_G2 operator*(const bigint<m> &lhs, const mnt6_G2 &rhs)
     return scalar_mul<mnt6_G2, m>(rhs, lhs);
 }
 
-template<mp_size_t m, const bigint<m>& modulus_p>
-mnt6_G2 operator*(const Fp_model<m,modulus_p> &lhs, const mnt6_G2 &rhs)
+template<typename T>
+mnt6_G2 operator*(const T &lhs, const mnt6_G2 &rhs)
 {
-    return scalar_mul<mnt6_G2, m>(rhs, lhs.as_bigint());
+    return scalar_mul<mnt6_G2, T::num_limbs>(rhs, lhs.as_bigint());
 }
 
 template<typename T>

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -38,9 +38,10 @@ bool is_little_endian();
 
 std::string FORMAT(const std::string &prefix, const char* format, ...);
 
+const std::string empty("");
 /* A variadic template to suppress unused argument warnings */
 template<typename ... Types>
-void UNUSED(Types&&...) {}
+const std::string& UNUSED(Types&&...) { return empty; }
 
 #ifdef DEBUG
 #define FMT FORMAT

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -45,7 +45,7 @@ void UNUSED(Types&&...) {}
 #ifdef DEBUG
 #define FMT FORMAT
 #else
-#define FMT(...) (UNUSED(__VA_ARGS__), "")
+#define FMT(...) UNUSED(__VA_ARGS__)
 #endif
 
 void serialize_bit_vector(std::ostream &out, const bit_vector &v);


### PR DESCRIPTION
This PR together with the one in libsnark has some solution for clang compatibility.

Specifically, it handles issues mentioned in #54 and #67 (in libsnark), about the following:
1. non-type template parameter deduction - by using a higher abstraction of the template parameter.
2. UNUSED macro in libff.