### PR TITLE
Fix FMT

### DIFF
--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -43,9 +43,9 @@ template<typename ... Types>
 void UNUSED(Types&&...) {}
 
 #ifdef DEBUG
-#define FMT FORMAT
+#define FMT libff::FORMAT
 #else
-#define FMT(...) (UNUSED(__VA_ARGS__), "")
+#define FMT(...) (libff::UNUSED(__VA_ARGS__), "")
 #endif
 
 void serialize_bit_vector(std::ostream &out, const bit_vector &v);

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -45,7 +45,7 @@ void UNUSED(Types&&...) {}
 #ifdef DEBUG
 #define FMT FORMAT
 #else
-#define FMT UNUSED
+#define FMT(...) (UNUSED(__VA_ARGS__), "")
 #endif
 
 void serialize_bit_vector(std::ostream &out, const bit_vector &v);


### PR DESCRIPTION
There were two problems with the FMT macro:

- it evaluated to values of different types (std::string or void) based on whether DEBUG was on, when it should always evaluate to a std::string

- it could not be used outside of the libff namespace, because it would be expanded into UNUSED, which is a function inside the libff namespace

The latter is a bigger problem, because macros really don't play well with namespaces. But these changes at least make it possible to use FMT outside libff (e.g. in libsnark).