### PR TITLE
Ensure everything compiles individually & sort includes

### DIFF
--- a/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp
@@ -8,6 +8,7 @@
 #ifndef ALT_BN128_G1_HPP_
 #define ALT_BN128_G1_HPP_
 #include <vector>
+
 #include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
 #include <libff/algebra/curves/curve_utils.hpp>
 

--- a/libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp
@@ -8,6 +8,7 @@
 #ifndef ALT_BN128_G2_HPP_
 #define ALT_BN128_G2_HPP_
 #include <vector>
+
 #include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
 #include <libff/algebra/curves/curve_utils.hpp>
 

--- a/libff/algebra/curves/alt_bn128/alt_bn128_init.cpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_init.cpp
@@ -5,9 +5,9 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp>
+#include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/alt_bn128/alt_bn128_init.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_init.hpp
@@ -9,9 +9,9 @@
 #define ALT_BN128_INIT_HPP_
 #include <libff/algebra/curves/public_params.hpp>
 #include <libff/algebra/fields/fp.hpp>
+#include <libff/algebra/fields/fp12_2over3over2.hpp>
 #include <libff/algebra/fields/fp2.hpp>
 #include <libff/algebra/fields/fp6_3over2.hpp>
-#include <libff/algebra/fields/fp12_2over3over2.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/alt_bn128/alt_bn128_pairing.cpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_pairing.cpp
@@ -5,11 +5,12 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <libff/algebra/curves/alt_bn128/alt_bn128_pairing.hpp>
-#include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
+#include <cassert>
+
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp>
-#include <cassert>
+#include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
+#include <libff/algebra/curves/alt_bn128/alt_bn128_pairing.hpp>
 #include <libff/common/profiling.hpp>
 
 namespace libff {

--- a/libff/algebra/curves/alt_bn128/alt_bn128_pairing.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_pairing.hpp
@@ -8,6 +8,7 @@
 #ifndef ALT_BN128_PAIRING_HPP_
 #define ALT_BN128_PAIRING_HPP_
 #include <vector>
+
 #include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
 
 namespace libff {

--- a/libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp
@@ -7,11 +7,11 @@
 
 #ifndef ALT_BN128_PP_HPP_
 #define ALT_BN128_PP_HPP_
-#include <libff/algebra/curves/public_params.hpp>
-#include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp>
+#include <libff/algebra/curves/alt_bn128/alt_bn128_init.hpp>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pairing.hpp>
+#include <libff/algebra/curves/public_params.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn128_g1.hpp
+++ b/libff/algebra/curves/bn128/bn128_g1.hpp
@@ -8,9 +8,11 @@
 #ifndef BN128_G1_HPP_
 #define BN128_G1_HPP_
 #include <vector>
+
+#include "third_party/ate-pairing/include/bn.h"
+
 #include <libff/algebra/curves/bn128/bn128_init.hpp>
 #include <libff/algebra/curves/curve_utils.hpp>
-#include "third_party/ate-pairing/include/bn.h"
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn128_g2.hpp
+++ b/libff/algebra/curves/bn128/bn128_g2.hpp
@@ -9,9 +9,11 @@
 #define BN128_G2_HPP_
 #include <iostream>
 #include <vector>
+
+#include "third_party/ate-pairing/include/bn.h"
+
 #include <libff/algebra/curves/bn128/bn128_init.hpp>
 #include <libff/algebra/curves/curve_utils.hpp>
-#include "third_party/ate-pairing/include/bn.h"
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn128_gt.hpp
+++ b/libff/algebra/curves/bn128/bn128_gt.hpp
@@ -7,10 +7,12 @@
 
 #ifndef BN128_GT_HPP_
 #define BN128_GT_HPP_
-#include <libff/algebra/fields/fp.hpp>
-#include <libff/algebra/fields/field_utils.hpp>
 #include <iostream>
+
 #include "third_party/ate-pairing/include/bn.h"
+
+#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/fields/fp.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn128_init.cpp
+++ b/libff/algebra/curves/bn128/bn128_init.cpp
@@ -5,10 +5,10 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <libff/algebra/curves/bn128/bn128_init.hpp>
 #include <libff/algebra/curves/bn128/bn128_g1.hpp>
 #include <libff/algebra/curves/bn128/bn128_g2.hpp>
 #include <libff/algebra/curves/bn128/bn128_gt.hpp>
+#include <libff/algebra/curves/bn128/bn128_init.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn128_init.hpp
+++ b/libff/algebra/curves/bn128/bn128_init.hpp
@@ -7,9 +7,10 @@
 
 #ifndef BN128_INIT_HPP_
 #define BN128_INIT_HPP_
+#include "third_party/ate-pairing/include/bn.h"
+
 #include <libff/algebra/curves/public_params.hpp>
 #include <libff/algebra/fields/fp.hpp>
-#include "third_party/ate-pairing/include/bn.h"
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn128_pairing.cpp
+++ b/libff/algebra/curves/bn128/bn128_pairing.cpp
@@ -10,12 +10,12 @@
 
 #include <sstream>
 
-#include <libff/algebra/curves/bn128/bn128_pairing.hpp>
-#include <libff/common/profiling.hpp>
-#include <libff/algebra/curves/bn128/bn128_init.hpp>
 #include <libff/algebra/curves/bn128/bn128_g1.hpp>
 #include <libff/algebra/curves/bn128/bn128_g2.hpp>
 #include <libff/algebra/curves/bn128/bn128_gt.hpp>
+#include <libff/algebra/curves/bn128/bn128_init.hpp>
+#include <libff/algebra/curves/bn128/bn128_pairing.hpp>
+#include <libff/common/profiling.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn128_pairing.hpp
+++ b/libff/algebra/curves/bn128/bn128_pairing.hpp
@@ -10,10 +10,11 @@
 
 #ifndef BN128_PAIRING_HPP_
 #define BN128_PAIRING_HPP_
+#include "third_party/ate-pairing/include/bn.h"
+
 #include <libff/algebra/curves/bn128/bn128_g1.hpp>
 #include <libff/algebra/curves/bn128/bn128_g2.hpp>
 #include <libff/algebra/curves/bn128/bn128_gt.hpp>
-#include "third_party/ate-pairing/include/bn.h"
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn128_pp.hpp
+++ b/libff/algebra/curves/bn128/bn128_pp.hpp
@@ -7,12 +7,12 @@
 
 #ifndef BN128_PP_HPP_
 #define BN128_PP_HPP_
-#include <libff/algebra/curves/public_params.hpp>
-#include <libff/algebra/curves/bn128/bn128_init.hpp>
 #include <libff/algebra/curves/bn128/bn128_g1.hpp>
 #include <libff/algebra/curves/bn128/bn128_g2.hpp>
 #include <libff/algebra/curves/bn128/bn128_gt.hpp>
+#include <libff/algebra/curves/bn128/bn128_init.hpp>
 #include <libff/algebra/curves/bn128/bn128_pairing.hpp>
+#include <libff/algebra/curves/public_params.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/bn128/bn_utils.hpp
+++ b/libff/algebra/curves/bn128/bn_utils.hpp
@@ -8,6 +8,7 @@
 #ifndef BN_UTILS_HPP_
 #define BN_UTILS_HPP_
 #include <vector>
+
 #include "third_party/ate-pairing/include/bn.h"
 
 namespace libff {

--- a/libff/algebra/curves/edwards/edwards_g1.hpp
+++ b/libff/algebra/curves/edwards/edwards_g1.hpp
@@ -8,8 +8,9 @@
 #ifndef EDWARDS_G1_HPP_
 #define EDWARDS_G1_HPP_
 #include <vector>
-#include <libff/algebra/curves/edwards/edwards_init.hpp>
+
 #include <libff/algebra/curves/curve_utils.hpp>
+#include <libff/algebra/curves/edwards/edwards_init.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/edwards/edwards_g2.hpp
+++ b/libff/algebra/curves/edwards/edwards_g2.hpp
@@ -9,8 +9,9 @@
 #define EDWARDS_G2_HPP_
 #include <iostream>
 #include <vector>
-#include <libff/algebra/curves/edwards/edwards_init.hpp>
+
 #include <libff/algebra/curves/curve_utils.hpp>
+#include <libff/algebra/curves/edwards/edwards_init.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/edwards/edwards_init.cpp
+++ b/libff/algebra/curves/edwards/edwards_init.cpp
@@ -5,9 +5,9 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <libff/algebra/curves/edwards/edwards_init.hpp>
 #include <libff/algebra/curves/edwards/edwards_g1.hpp>
 #include <libff/algebra/curves/edwards/edwards_g2.hpp>
+#include <libff/algebra/curves/edwards/edwards_init.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/edwards/edwards_pairing.cpp
+++ b/libff/algebra/curves/edwards/edwards_pairing.cpp
@@ -5,11 +5,12 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <libff/algebra/curves/edwards/edwards_pairing.hpp>
-#include <libff/algebra/curves/edwards/edwards_init.hpp>
 #include <cassert>
+
 #include <libff/algebra/curves/edwards/edwards_g1.hpp>
 #include <libff/algebra/curves/edwards/edwards_g2.hpp>
+#include <libff/algebra/curves/edwards/edwards_init.hpp>
+#include <libff/algebra/curves/edwards/edwards_pairing.hpp>
 #include <libff/common/profiling.hpp>
 
 namespace libff {

--- a/libff/algebra/curves/edwards/edwards_pairing.hpp
+++ b/libff/algebra/curves/edwards/edwards_pairing.hpp
@@ -8,6 +8,7 @@
 #ifndef EDWARDS_PAIRING_HPP_
 #define EDWARDS_PAIRING_HPP_
 #include <vector>
+
 #include <libff/algebra/curves/edwards/edwards_init.hpp>
 
 namespace libff {

--- a/libff/algebra/curves/edwards/edwards_pp.hpp
+++ b/libff/algebra/curves/edwards/edwards_pp.hpp
@@ -7,11 +7,11 @@
 
 #ifndef EDWARDS_PP_HPP_
 #define EDWARDS_PP_HPP_
-#include <libff/algebra/curves/public_params.hpp>
-#include <libff/algebra/curves/edwards/edwards_init.hpp>
 #include <libff/algebra/curves/edwards/edwards_g1.hpp>
 #include <libff/algebra/curves/edwards/edwards_g2.hpp>
+#include <libff/algebra/curves/edwards/edwards_init.hpp>
 #include <libff/algebra/curves/edwards/edwards_pairing.hpp>
+#include <libff/algebra/curves/public_params.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_init.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_init.cpp
@@ -11,9 +11,9 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <libff/algebra/curves/mnt/mnt4/mnt4_init.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp>
+#include <libff/algebra/curves/mnt/mnt4/mnt4_init.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_init.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_init.hpp
@@ -12,8 +12,8 @@
 #ifndef MNT4_INIT_HPP_
 #define MNT4_INIT_HPP_
 
-#include <libff/algebra/curves/public_params.hpp>
 #include <libff/algebra/curves/mnt/mnt46_common.hpp>
+#include <libff/algebra/curves/public_params.hpp>
 #include <libff/algebra/fields/fp.hpp>
 #include <libff/algebra/fields/fp2.hpp>
 #include <libff/algebra/fields/fp4.hpp>

--- a/libff/algebra/curves/mnt/mnt4/mnt4_pairing.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_pairing.cpp
@@ -13,11 +13,10 @@
 
 #include <cassert>
 
-#include <libff/algebra/curves/mnt/mnt4/mnt4_pairing.hpp>
-
-#include <libff/algebra/curves/mnt/mnt4/mnt4_init.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp>
+#include <libff/algebra/curves/mnt/mnt4/mnt4_init.hpp>
+#include <libff/algebra/curves/mnt/mnt4/mnt4_pairing.hpp>
 #include <libff/algebra/scalar_multiplication/wnaf.hpp>
 #include <libff/common/profiling.hpp>
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp
@@ -12,11 +12,11 @@
 #ifndef MNT4_PP_HPP_
 #define MNT4_PP_HPP_
 
-#include <libff/algebra/curves/public_params.hpp>
-#include <libff/algebra/curves/mnt/mnt4/mnt4_init.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp>
+#include <libff/algebra/curves/mnt/mnt4/mnt4_init.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pairing.hpp>
+#include <libff/algebra/curves/public_params.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_init.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_init.cpp
@@ -11,9 +11,9 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_init.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_init.hpp
@@ -12,8 +12,8 @@
 #ifndef MNT6_INIT_HPP_
 #define MNT6_INIT_HPP_
 
-#include <libff/algebra/curves/public_params.hpp>
 #include <libff/algebra/curves/mnt/mnt46_common.hpp>
+#include <libff/algebra/curves/public_params.hpp>
 #include <libff/algebra/fields/fp.hpp>
 #include <libff/algebra/fields/fp3.hpp>
 #include <libff/algebra/fields/fp6_2over3.hpp>

--- a/libff/algebra/curves/mnt/mnt6/mnt6_pairing.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_pairing.cpp
@@ -13,10 +13,10 @@
 
 #include <cassert>
 
-#include <libff/algebra/curves/mnt/mnt6/mnt6_pairing.hpp>
-#include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pairing.hpp>
 #include <libff/algebra/scalar_multiplication/wnaf.hpp>
 #include <libff/common/profiling.hpp>
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp
@@ -12,11 +12,11 @@
 #ifndef MNT6_PP_HPP_
 #define MNT6_PP_HPP_
 
-#include <libff/algebra/curves/public_params.hpp>
-#include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pairing.hpp>
+#include <libff/algebra/curves/public_params.hpp>
 
 namespace libff {
 

--- a/libff/algebra/curves/tests/test_bilinearity.cpp
+++ b/libff/algebra/curves/tests/test_bilinearity.cpp
@@ -4,8 +4,8 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include <libff/common/profiling.hpp>
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
+#include <libff/common/profiling.hpp>
 #ifdef CURVE_BN128
 #include <libff/algebra/curves/bn128/bn128_pp.hpp>
 #endif

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -4,15 +4,16 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include <libff/common/profiling.hpp>
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/common/profiling.hpp>
 #ifdef CURVE_BN128
 #include <libff/algebra/curves/bn128/bn128_pp.hpp>
 #endif
-#include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <sstream>
+
+#include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 
 using namespace libff;
 

--- a/libff/algebra/fields/bigint.hpp
+++ b/libff/algebra/fields/bigint.hpp
@@ -11,7 +11,9 @@
 #define BIGINT_HPP_
 #include <cstddef>
 #include <iostream>
+
 #include <gmp.h>
+
 #include <libff/common/serialization.hpp>
 
 namespace libff {

--- a/libff/algebra/fields/field_utils.tcc
+++ b/libff/algebra/fields/field_utils.tcc
@@ -12,7 +12,7 @@
 
 #include <complex>
 #include <stdexcept>
- 
+
 #include <libff/common/double.hpp>
 #include <libff/common/utils.hpp>
 

--- a/libff/algebra/fields/fp.hpp
+++ b/libff/algebra/fields/fp.hpp
@@ -10,8 +10,8 @@
 #ifndef FP_HPP_
 #define FP_HPP_
 
-#include <libff/algebra/fields/bigint.hpp>
 #include <libff/algebra/exponentiation/exponentiation.hpp>
+#include <libff/algebra/fields/bigint.hpp>
 
 namespace libff {
 

--- a/libff/algebra/fields/fp.tcc
+++ b/libff/algebra/fields/fp.tcc
@@ -10,12 +10,12 @@
 #ifndef FP_TCC_
 #define FP_TCC_
 #include <cassert>
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
 #include <limits>
 
-#include <libff/algebra/fields/fp_aux.tcc>
 #include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/fields/fp_aux.tcc>
 
 namespace libff {
 

--- a/libff/algebra/fields/fp12_2over3over2.hpp
+++ b/libff/algebra/fields/fp12_2over3over2.hpp
@@ -9,10 +9,11 @@
 
 #ifndef FP12_2OVER3OVER2_HPP_
 #define FP12_2OVER3OVER2_HPP_
+#include <vector>
+
 #include <libff/algebra/fields/fp.hpp>
 #include <libff/algebra/fields/fp2.hpp>
 #include <libff/algebra/fields/fp6_3over2.hpp>
-#include <vector>
 
 namespace libff {
 

--- a/libff/algebra/fields/fp2.hpp
+++ b/libff/algebra/fields/fp2.hpp
@@ -9,8 +9,9 @@
 
 #ifndef FP2_HPP_
 #define FP2_HPP_
-#include <libff/algebra/fields/fp.hpp>
 #include <vector>
+
+#include <libff/algebra/fields/fp.hpp>
 
 namespace libff {
 

--- a/libff/algebra/fields/fp3.hpp
+++ b/libff/algebra/fields/fp3.hpp
@@ -9,8 +9,9 @@
 
 #ifndef FP3_HPP_
 #define FP3_HPP_
-#include <libff/algebra/fields/fp.hpp>
 #include <vector>
+
+#include <libff/algebra/fields/fp.hpp>
 
 namespace libff {
 

--- a/libff/algebra/fields/fp6_3over2.hpp
+++ b/libff/algebra/fields/fp6_3over2.hpp
@@ -9,9 +9,10 @@
 
 #ifndef FP6_3OVER2_HPP_
 #define FP6_3OVER2_HPP_
+#include <vector>
+
 #include <libff/algebra/fields/fp.hpp>
 #include <libff/algebra/fields/fp2.hpp>
-#include <vector>
 
 namespace libff {
 

--- a/libff/algebra/fields/tests/test_fields.cpp
+++ b/libff/algebra/fields/tests/test_fields.cpp
@@ -4,16 +4,16 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include <libff/common/profiling.hpp>
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/common/profiling.hpp>
 #ifdef CURVE_BN128
 #include <libff/algebra/curves/bn128/bn128_pp.hpp>
 #endif
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
-#include <libff/algebra/fields/fp6_3over2.hpp>
 #include <libff/algebra/fields/fp12_2over3over2.hpp>
+#include <libff/algebra/fields/fp6_3over2.hpp>
 
 using namespace libff;
 

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -12,6 +12,8 @@
 #ifndef MULTIEXP_HPP_
 #define MULTIEXP_HPP_
 
+#include <vector>
+
 namespace libff {
 
 /**

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -14,15 +14,14 @@
 #ifndef MULTIEXP_TCC_
 #define MULTIEXP_TCC_
 
-#include <libff/algebra/fields/fp_aux.tcc>
-
 #include <algorithm>
 #include <cassert>
 #include <type_traits>
 
+#include <libff/algebra/fields/fp_aux.tcc>
+#include <libff/algebra/scalar_multiplication/wnaf.hpp>
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
-#include <libff/algebra/scalar_multiplication/wnaf.hpp>
 
 namespace libff {
 

--- a/libff/algebra/scalar_multiplication/wnaf.hpp
+++ b/libff/algebra/scalar_multiplication/wnaf.hpp
@@ -12,6 +12,10 @@
 #ifndef WNAF_HPP_
 #define WNAF_HPP_
 
+#include <vector>
+
+#include <libff/algebra/fields/bigint.hpp>
+
 namespace libff {
 
 /**

--- a/libff/algebra/scalar_multiplication/wnaf.tcc
+++ b/libff/algebra/scalar_multiplication/wnaf.tcc
@@ -14,6 +14,8 @@
 #ifndef WNAF_TCC_
 #define WNAF_TCC_
 
+#include <gmp.h>
+
 namespace libff {
 
 template<mp_size_t n>

--- a/libff/common/default_types/ec_pp.hpp
+++ b/libff/common/default_types/ec_pp.hpp
@@ -16,6 +16,7 @@
 /************************ Pick the elliptic curve ****************************/
 
 #ifdef CURVE_ALT_BN128
+#define LIBFF_DEFAULT_EC_PP_DEFINED
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 namespace libff {
 typedef alt_bn128_pp default_ec_pp;
@@ -23,6 +24,7 @@ typedef alt_bn128_pp default_ec_pp;
 #endif
 
 #ifdef CURVE_BN128
+#define LIBFF_DEFAULT_EC_PP_DEFINED
 #include <libff/algebra/curves/bn128/bn128_pp.hpp>
 namespace libff {
 typedef bn128_pp default_ec_pp;
@@ -30,6 +32,7 @@ typedef bn128_pp default_ec_pp;
 #endif
 
 #ifdef CURVE_EDWARDS
+#define LIBFF_DEFAULT_EC_PP_DEFINED
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
 namespace libff {
 typedef edwards_pp default_ec_pp;
@@ -37,6 +40,7 @@ typedef edwards_pp default_ec_pp;
 #endif
 
 #ifdef CURVE_MNT4
+#define LIBFF_DEFAULT_EC_PP_DEFINED
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 namespace libff {
 typedef mnt4_pp default_ec_pp;
@@ -44,10 +48,15 @@ typedef mnt4_pp default_ec_pp;
 #endif
 
 #ifdef CURVE_MNT6
+#define LIBFF_DEFAULT_EC_PP_DEFINED
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
 namespace libff {
 typedef mnt6_pp default_ec_pp;
 } // libff
+#endif
+
+#ifndef LIBFF_DEFAULT_EC_PP_DEFINED
+#error You must define one of the CURVE_* symbols to pick a curve for pairings.
 #endif
 
 #endif // EC_PP_HPP_

--- a/libff/common/double.cpp
+++ b/libff/common/double.cpp
@@ -9,12 +9,12 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <complex>
 #include <cmath>
+#include <complex>
+
 #include <math.h>
 
 #include <libff/algebra/fields/bigint.hpp>
-
 #include <libff/common/double.hpp>
 
 namespace libff {

--- a/libff/common/double.hpp
+++ b/libff/common/double.hpp
@@ -13,6 +13,7 @@
 #define DOUBLE_HPP_
 
 #include <complex>
+
 #include <libff/algebra/fields/bigint.hpp>
 
 namespace libff {

--- a/libff/common/profiling.cpp
+++ b/libff/common/profiling.cpp
@@ -11,15 +11,16 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include <libff/common/profiling.hpp>
 #include <cassert>
-#include <stdexcept>
 #include <chrono>
 #include <cstdio>
-#include <list>
-#include <vector>
 #include <ctime>
+#include <list>
+#include <stdexcept>
+#include <vector>
+
 #include <libff/common/default_types/ec_pp.hpp>
+#include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 
 #ifndef NO_PROCPS

--- a/libff/common/rng.tcc
+++ b/libff/common/rng.tcc
@@ -14,7 +14,12 @@
 #ifndef RNG_TCC_
 #define RNG_TCC_
 
+#include <gmp.h>
 #include <openssl/sha.h>
+
+#include <libff/algebra/fields/bigint.hpp>
+#include <libff/common/rng.hpp>
+#include <libff/common/utils.hpp>
 
 namespace libff {
 

--- a/libff/common/serialization.tcc
+++ b/libff/common/serialization.tcc
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <sstream>
+
 #include <libff/common/utils.hpp>
 
 namespace libff {

--- a/libff/common/utils.cpp
+++ b/libff/common/utils.cpp
@@ -9,8 +9,9 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstdint>
 #include <cstdarg>
+#include <cstdint>
+
 #include <libff/common/utils.hpp>
 
 namespace libff {


### PR DESCRIPTION
A lot of the files in our codebase don't properly include all of their dependencies. A common example of this is a situation like this: `a.hpp` uses `std::vector` in a definition, so it would need to have a line saying `#include <vector>`, but it doesn't. `a.hpp` does not include `vector` neither directly nor indirectly, but whenever `a.hpp` is included from another file, that file just happens to include `vector` beforehand.

The result is that, while running `make` succeeds, the code is quite brittle. The fact that `vector` is always included before `a.hpp` (in *current* uses of the library) might be quite accidental, and users might in theory want to use `a.hpp` in another file that doesn't need `vector` itself. Besides, it's just not particularly good style to not include our dependencies explicitly.

Luckily, this specific problem is easy to detect: if you were to try to compile `a.hpp` on its own, compilation would not succeed. I wrote a script (`try_compiling.py` in `libsnark-tooling`) that tries to individually compile every single file (`*.hpp` or `*.cpp`) in libff and reports whether it succeeds.

I then went through the report and fixed every single compilation error --- almost all of them were because of missing includes.

This does not resolve all possible include-related problems: in the situation above, perhaps `a.hpp` actually has a line saying `#include <libff/b.hpp>`, and `b.hpp` includes `vector` --- then `a.hpp` compiles just fine, but is still not explicitly listing all of its dependencies (perhaps `b.hpp`'s dependencies will change in the future, and it will no longer require `vector` --- then we'll get a broken `a.hpp` despite no real changes inside it). But I think this is a much smaller problem, and it's also much harder to even detect automatically, so for now I'm submitting just these changes.

While I was at it, I also sorted the #include directives in every file --- they are now grouped into three groups (standard library, external libraries, and libff) and sorted lexicographically within each group. This was done using `fix-includes.py` in `libsnark-tooling`.

Another minor change I made is that `libff/common/default_types/ec_pp.hpp` will now refuse to compile (with a helpful error message) if none of the `CURVE_*` symbols are defined, because that file is always included with the expectation that it will define `default_ec_pp`.