### PR TITLE
Multiexponentiation improvements

### DIFF
--- a/libff/CMakeLists.txt
+++ b/libff/CMakeLists.txt
@@ -74,6 +74,18 @@ install(
   TARGETS ff DESTINATION lib
 )
 
+add_executable(
+  multiexp_profile
+  EXCLUDE_FROM_ALL
+
+  algebra/scalar_multiplication/multiexp_profile.cpp
+)
+target_link_libraries(
+  multiexp_profile
+
+  ff
+)
+
 # Tests
 add_executable(
   algebra_bilinearity_test

--- a/libff/algebra/curves/alt_bn128/alt_bn128_g1.cpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g1.cpp
@@ -496,8 +496,7 @@ std::istream& operator>>(std::istream& in, std::vector<alt_bn128_G1> &v)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<alt_bn128_G1>(std::vector<alt_bn128_G1> &vec)
+void alt_bn128_G1::batch_to_special_all_non_zeros(std::vector<alt_bn128_G1> &vec)
 {
     std::vector<alt_bn128_Fq> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp
@@ -70,6 +70,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const alt_bn128_G1 &g);
     friend std::istream& operator>>(std::istream &in, alt_bn128_G1 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<alt_bn128_G1> &vec);
 };
 
 template<mp_size_t m>
@@ -86,11 +88,6 @@ alt_bn128_G1 operator*(const Fp_model<m,modulus_p> &lhs, const alt_bn128_G1 &rhs
 
 std::ostream& operator<<(std::ostream& out, const std::vector<alt_bn128_G1> &v);
 std::istream& operator>>(std::istream& in, std::vector<alt_bn128_G1> &v);
-
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<alt_bn128_G1>(std::vector<alt_bn128_G1> &vec);
 
 } // libff
 #endif // ALT_BN128_G1_HPP_

--- a/libff/algebra/curves/alt_bn128/alt_bn128_g2.cpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g2.cpp
@@ -477,8 +477,7 @@ std::istream& operator>>(std::istream &in, alt_bn128_G2 &g)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<alt_bn128_G2>(std::vector<alt_bn128_G2> &vec)
+void alt_bn128_G2::batch_to_special_all_non_zeros(std::vector<alt_bn128_G2> &vec)
 {
     std::vector<alt_bn128_Fq2> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp
@@ -74,6 +74,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const alt_bn128_G2 &g);
     friend std::istream& operator>>(std::istream &in, alt_bn128_G2 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<alt_bn128_G2> &vec);
 };
 
 template<mp_size_t m>
@@ -88,10 +90,6 @@ alt_bn128_G2 operator*(const Fp_model<m,modulus_p> &lhs, const alt_bn128_G2 &rhs
     return scalar_mul<alt_bn128_G2, m>(rhs, lhs.as_bigint());
 }
 
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<alt_bn128_G2>(std::vector<alt_bn128_G2> &vec);
 
 } // libff
 #endif // ALT_BN128_G2_HPP_

--- a/libff/algebra/curves/bn128/bn128_g1.cpp
+++ b/libff/algebra/curves/bn128/bn128_g1.cpp
@@ -491,8 +491,7 @@ std::istream& operator>>(std::istream& in, std::vector<bn128_G1> &v)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<bn128_G1>(std::vector<bn128_G1> &vec)
+void bn128_G1::batch_to_special_all_non_zeros(std::vector<bn128_G1> &vec)
 {
     std::vector<bn::Fp> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/bn128/bn128_g1.hpp
+++ b/libff/algebra/curves/bn128/bn128_g1.hpp
@@ -70,6 +70,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const bn128_G1 &g);
     friend std::istream& operator>>(std::istream &in, bn128_G1 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<bn128_G1> &vec);
 };
 
 template<mp_size_t m>
@@ -87,10 +89,6 @@ bn128_G1 operator*(const Fp_model<m,modulus_p> &lhs, const bn128_G1 &rhs)
 std::ostream& operator<<(std::ostream& out, const std::vector<bn128_G1> &v);
 std::istream& operator>>(std::istream& in, std::vector<bn128_G1> &v);
 
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<bn128_G1>(std::vector<bn128_G1> &vec);
 
 } // libff
 #endif // BN128_G1_HPP_

--- a/libff/algebra/curves/bn128/bn128_g2.cpp
+++ b/libff/algebra/curves/bn128/bn128_g2.cpp
@@ -474,8 +474,7 @@ std::istream& operator>>(std::istream &in, bn128_G2 &g)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<bn128_G2>(std::vector<bn128_G2> &vec)
+void bn128_G2::batch_to_special_all_non_zeros(std::vector<bn128_G2> &vec)
 {
     std::vector<bn::Fp2> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/bn128/bn128_g2.hpp
+++ b/libff/algebra/curves/bn128/bn128_g2.hpp
@@ -71,6 +71,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const bn128_G2 &g);
     friend std::istream& operator>>(std::istream &in, bn128_G2 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<bn128_G2> &vec);
 };
 
 template<mp_size_t m>
@@ -84,11 +86,6 @@ bn128_G2 operator*(const Fp_model<m, modulus_p> &lhs, const bn128_G2 &rhs)
 {
     return scalar_mul<bn128_G2, m>(rhs, lhs.as_bigint());
 }
-
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<bn128_G2>(std::vector<bn128_G2> &vec);
 
 } // libff
 #endif // BN128_G2_HPP_

--- a/libff/algebra/curves/edwards/edwards_g1.cpp
+++ b/libff/algebra/curves/edwards/edwards_g1.cpp
@@ -388,8 +388,7 @@ std::istream& operator>>(std::istream& in, std::vector<edwards_G1> &v)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<edwards_G1>(std::vector<edwards_G1> &vec)
+void edwards_G1::batch_to_special_all_non_zeros(std::vector<edwards_G1> &vec)
 {
     std::vector<edwards_Fq> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/edwards/edwards_g1.hpp
+++ b/libff/algebra/curves/edwards/edwards_g1.hpp
@@ -72,6 +72,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const edwards_G1 &g);
     friend std::istream& operator>>(std::istream &in, edwards_G1 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<edwards_G1> &vec);
 };
 
 template<mp_size_t m>
@@ -88,11 +90,6 @@ edwards_G1 operator*(const Fp_model<m,modulus_p> &lhs, const edwards_G1 &rhs)
 
 std::ostream& operator<<(std::ostream& out, const std::vector<edwards_G1> &v);
 std::istream& operator>>(std::istream& in, std::vector<edwards_G1> &v);
-
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<edwards_G1>(std::vector<edwards_G1> &vec);
 
 } // libff
 #endif // EDWARDS_G1_HPP_

--- a/libff/algebra/curves/edwards/edwards_g2.cpp
+++ b/libff/algebra/curves/edwards/edwards_g2.cpp
@@ -389,10 +389,7 @@ std::istream& operator>>(std::istream &in, edwards_G2 &g)
     return in;
 }
 
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<edwards_G2>(std::vector<edwards_G2> &vec)
+void edwards_G2::batch_to_special_all_non_zeros(std::vector<edwards_G2> &vec)
 {
     std::vector<edwards_Fq3> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/edwards/edwards_g2.hpp
+++ b/libff/algebra/curves/edwards/edwards_g2.hpp
@@ -78,6 +78,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const edwards_G2 &g);
     friend std::istream& operator>>(std::istream &in, edwards_G2 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<edwards_G2> &vec);
 };
 
 template<mp_size_t m>
@@ -91,11 +93,6 @@ edwards_G2 operator*(const Fp_model<m, modulus_p> &lhs, const edwards_G2 &rhs)
 {
    return scalar_mul<edwards_G2, m>(rhs, lhs.as_bigint());
 }
-
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<edwards_G2>(std::vector<edwards_G2> &vec);
 
 } // libff
 #endif // EDWARDS_G2_HPP_

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g1.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g1.cpp
@@ -482,8 +482,7 @@ std::istream& operator>>(std::istream& in, std::vector<mnt4_G1> &v)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<mnt4_G1>(std::vector<mnt4_G1> &vec)
+void mnt4_G1::batch_to_special_all_non_zeros(std::vector<mnt4_G1> &vec)
 {
     std::vector<mnt4_Fq> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp
@@ -82,6 +82,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const mnt4_G1 &g);
     friend std::istream& operator>>(std::istream &in, mnt4_G1 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<mnt4_G1> &vec);
 };
 
 template<mp_size_t m>
@@ -98,11 +100,6 @@ mnt4_G1 operator*(const Fp_model<m,modulus_p> &lhs, const mnt4_G1 &rhs)
 
 std::ostream& operator<<(std::ostream& out, const std::vector<mnt4_G1> &v);
 std::istream& operator>>(std::istream& in, std::vector<mnt4_G1> &v);
-
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<mnt4_G1>(std::vector<mnt4_G1> &vec);
 
 } // libff
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g2.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g2.cpp
@@ -473,8 +473,7 @@ std::istream& operator>>(std::istream &in, mnt4_G2 &g)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<mnt4_G2>(std::vector<mnt4_G2> &vec)
+void mnt4_G2::batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec)
 {
     std::vector<mnt4_Fq2> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp
@@ -87,6 +87,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const mnt4_G2 &g);
     friend std::istream& operator>>(std::istream &in, mnt4_G2 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec);
 };
 
 template<mp_size_t m>
@@ -100,11 +102,6 @@ mnt4_G2 operator*(const Fp_model<m,modulus_p> &lhs, const mnt4_G2 &rhs)
 {
     return scalar_mul<mnt4_G2, m>(rhs, lhs.as_bigint());
 }
-
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<mnt4_G2>(std::vector<mnt4_G2> &vec);
 
 } // libff
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g1.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g1.cpp
@@ -481,8 +481,7 @@ std::istream& operator>>(std::istream& in, std::vector<mnt6_G1> &v)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<mnt6_G1>(std::vector<mnt6_G1> &vec)
+void mnt6_G1::batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec)
 {
     std::vector<mnt6_Fq> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp
@@ -82,6 +82,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const mnt6_G1 &g);
     friend std::istream& operator>>(std::istream &in, mnt6_G1 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec);
 };
 
 template<mp_size_t m>
@@ -98,11 +100,6 @@ mnt6_G1 operator*(const Fp_model<m,modulus_p> &lhs, const mnt6_G1 &rhs)
 
 std::ostream& operator<<(std::ostream& out, const std::vector<mnt6_G1> &v);
 std::istream& operator>>(std::istream& in, std::vector<mnt6_G1> &v);
-
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<mnt6_G1>(std::vector<mnt6_G1> &vec);
 
 } // libff
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g2.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g2.cpp
@@ -480,8 +480,7 @@ std::istream& operator>>(std::istream &in, mnt6_G2 &g)
     return in;
 }
 
-template<>
-void batch_to_special_all_non_zeros<mnt6_G2>(std::vector<mnt6_G2> &vec)
+void mnt6_G2::batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec)
 {
     std::vector<mnt6_Fq3> Z_vec;
     Z_vec.reserve(vec.size());

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp
@@ -87,6 +87,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &out, const mnt6_G2 &g);
     friend std::istream& operator>>(std::istream &in, mnt6_G2 &g);
+
+    static void batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec);
 };
 
 template<mp_size_t m>
@@ -100,11 +102,6 @@ mnt6_G2 operator*(const Fp_model<m,modulus_p> &lhs, const mnt6_G2 &rhs)
 {
     return scalar_mul<mnt6_G2, m>(rhs, lhs.as_bigint());
 }
-
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-template<>
-void batch_to_special_all_non_zeros<mnt6_G2>(std::vector<mnt6_G2> &vec);
 
 } // libff
 

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -73,6 +73,16 @@ T multi_exp_with_mixed_addition(typename std::vector<T>::const_iterator vec_star
                                 const size_t chunks);
 
 /**
+ * A convenience function for calculating a pure inner product, where the
+ * more complicated methods are not required.
+ */
+template <typename T>
+T inner_product(typename std::vector<T>::const_iterator a_start,
+                typename std::vector<T>::const_iterator a_end,
+                typename std::vector<T>::const_iterator b_start,
+                typename std::vector<T>::const_iterator b_end);
+
+/**
  * A window table stores window sizes for different instance sizes for fixed-base multi-scalar multiplications.
  */
 template<typename T>

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -47,6 +47,8 @@ T simul_2w_multi_exp(typename std::vector<T>::const_iterator bases,
 /*
  * A special case of Pippenger's algorithm from Page 15 of
  * https://eprint.iacr.org/2012/549.pdf
+ * When compiled with USE_MIXED_ADDITION, assumes input is
+ * in special form.
  */
 template<typename T, typename FieldT>
 T multi_exp_djb(typename std::vector<T>::const_iterator bases,

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -121,10 +121,6 @@ std::vector<T> batch_exp_with_coeff(const size_t scalar_size,
                                     const FieldT &coeff,
                                     const std::vector<FieldT> &v);
 
-// defined in every curve
-template<typename T>
-void batch_to_special_all_non_zeros(std::vector<T> &vec);
-
 template<typename T>
 void batch_to_special(std::vector<T> &vec);
 

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -34,6 +34,17 @@ T naive_plain_exp(typename std::vector<T>::const_iterator vec_start,
                   typename std::vector<FieldT>::const_iterator scalar_end);
 
 /**
+ * Simultaneous 2^w-ary method,
+ * Section 2.1 of Bodo Moller, "Algorithms for multi-exponentiation", SAC '01
+ */
+template<typename T, typename FieldT>
+T simul_2w_multi_exp(typename std::vector<T>::const_iterator bases,
+                     typename std::vector<T>::const_iterator bases_end,
+                     typename std::vector<FieldT>::const_iterator exponents,
+                     typename std::vector<FieldT>::const_iterator exponents_end,
+                     size_t chunk_length);
+
+/**
  * Naive multi-exponentiation uses a variant of the Bos-Coster algorithm [1],
  * and implementation suggestions from [2].
  *

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -12,6 +12,7 @@
 #ifndef MULTIEXP_HPP_
 #define MULTIEXP_HPP_
 
+#include <cstddef>
 #include <vector>
 
 namespace libff {

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -44,6 +44,17 @@ T simul_2w_multi_exp(typename std::vector<T>::const_iterator bases,
                      typename std::vector<FieldT>::const_iterator exponents_end,
                      size_t chunk_length);
 
+/*
+ * A special case of Pippenger's algorithm from Page 15 of
+ * https://eprint.iacr.org/2012/549.pdf
+ */
+template<typename T, typename FieldT>
+T multi_exp_djb(typename std::vector<T>::const_iterator bases,
+                typename std::vector<T>::const_iterator bases_end,
+                typename std::vector<FieldT>::const_iterator exponents,
+                typename std::vector<FieldT>::const_iterator exponents_end,
+                size_t c);
+
 /**
  * Naive multi-exponentiation uses a variant of the Bos-Coster algorithm [1],
  * and implementation suggestions from [2].

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -36,12 +36,14 @@ enum multi_exp_method {
  multi_exp_method_bos_coster,
  /**
   * A special case of Pippenger's algorithm from Page 15 of
-  * https://eprint.iacr.org/2012/549.pdf
+  * Bernstein, Doumen, Lange, Oosterwijk,
+  * "Faster batch forgery identification", INDOCRYPT 2012
+  * (https://eprint.iacr.org/2012/549.pdf)
   * When compiled with USE_MIXED_ADDITION, assumes input is in special form.
   * Requires that T implements .dbl() (and, if USE_MIXED_ADDITION is defined,
   * .to_special(), .mixed_add(), and batch_to_special()).
   */
- multi_exp_method_djb
+ multi_exp_method_BDLO12
 };
 
 /**

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -53,7 +53,7 @@ T multi_exp_djb(typename std::vector<T>::const_iterator bases,
                 typename std::vector<T>::const_iterator bases_end,
                 typename std::vector<FieldT>::const_iterator exponents,
                 typename std::vector<FieldT>::const_iterator exponents_end,
-                size_t c);
+                size_t c = 0);
 
 /**
  * Naive multi-exponentiation uses a variant of the Bos-Coster algorithm [1],

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -495,6 +495,17 @@ T multi_exp_with_mixed_addition(typename std::vector<T>::const_iterator vec_star
     return acc + multi_exp<T, FieldT, Method>(g.begin(), g.end(), p.begin(), p.end(), chunks);
 }
 
+template <typename T>
+T inner_product(typename std::vector<T>::const_iterator a_start,
+                typename std::vector<T>::const_iterator a_end,
+                typename std::vector<T>::const_iterator b_start,
+                typename std::vector<T>::const_iterator b_end)
+{
+    return multi_exp<T, T, multi_exp_method_naive_plain>(
+        a_start, a_end,
+        b_start, b_end, 1);
+}
+
 template<typename T>
 size_t get_exp_window_size(const size_t num_scalars)
 {

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -345,7 +345,11 @@ T multi_exp_djb(typename std::vector<T>::const_iterator bases,
 
             if (bucket_nonzero[id])
             {
+#ifdef USE_MIXED_ADDITION
+                buckets[id] = buckets[id].mixed_add(bases[i]);
+#else
                 buckets[id] = buckets[id] + bases[i];
+#endif
             }
             else
             {
@@ -353,6 +357,10 @@ T multi_exp_djb(typename std::vector<T>::const_iterator bases,
                 bucket_nonzero[id] = true;
             }
         }
+
+#ifdef USE_MIXED_ADDITION
+        batch_to_special(buckets);
+#endif
 
         T running_sum;
         bool running_sum_nonzero = false;
@@ -363,7 +371,11 @@ T multi_exp_djb(typename std::vector<T>::const_iterator bases,
             {
                 if (running_sum_nonzero)
                 {
+#ifdef USE_MIXED_ADDITION
+                    running_sum = running_sum.mixed_add(buckets[i]);
+#else
                     running_sum = running_sum + buckets[i];
+#endif
                 }
                 else
                 {

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -280,6 +280,8 @@ T simul_2w_multi_exp(typename std::vector<T>::const_iterator bases,
 /*
  * A special case of Pippenger's algorithm from Page 15 of
  * https://eprint.iacr.org/2012/549.pdf
+ * When compiled with USE_MIXED_ADDITION, assumes input is
+ * in special form.
  */
 template<typename T, typename FieldT>
 T multi_exp_djb(typename std::vector<T>::const_iterator bases,

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -694,7 +694,7 @@ void batch_to_special(std::vector<T> &vec)
         }
     }
 
-    batch_to_special_all_non_zeros<T>(non_zero_vec);
+    T::batch_to_special_all_non_zeros(non_zero_vec);
     auto it = non_zero_vec.begin();
     T zero_special = T::zero();
     zero_special.to_special();

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -289,8 +289,15 @@ T multi_exp_djb(typename std::vector<T>::const_iterator bases,
                 size_t c)
 {
     UNUSED(exponents_end);
-
     size_t length = bases_end - bases;
+
+    if (c == 0)
+    {
+        // empirically, this seems to be a decent estimate of the optimal value of c
+        size_t log2_length = log2(length);
+        c = log2_length - (log2_length / 3 - 2);
+    }
+
     const mp_size_t exp_num_limbs =
         std::remove_reference<decltype(*exponents)>::type::num_limbs;
     std::vector<bigint<exp_num_limbs> > bn_exponents(length);

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -163,7 +163,7 @@ T multi_exp_inner(
 }
 
 template<typename T, typename FieldT, multi_exp_method Method,
-    typename std::enable_if<(Method == multi_exp_method_djb), int>::type = 0>
+    typename std::enable_if<(Method == multi_exp_method_BDLO12), int>::type = 0>
 T multi_exp_inner(
     typename std::vector<T>::const_iterator bases,
     typename std::vector<T>::const_iterator bases_end,

--- a/libff/algebra/scalar_multiplication/multiexp_profile.cpp
+++ b/libff/algebra/scalar_multiplication/multiexp_profile.cpp
@@ -90,7 +90,7 @@ void print_performance_csv(
         printf("\t%lld", result_bos_coster.first); fflush(stdout);
 
         run_result_t<GroupT> result_djb =
-            profile_multiexp<GroupT, FieldT, multi_exp_method_djb>(
+            profile_multiexp<GroupT, FieldT, multi_exp_method_BDLO12>(
                 group_elements, scalars);
         printf("\t%lld", result_djb.first); fflush(stdout);
 

--- a/libff/algebra/scalar_multiplication/multiexp_profile.cpp
+++ b/libff/algebra/scalar_multiplication/multiexp_profile.cpp
@@ -1,0 +1,78 @@
+#include <cstdio>
+#include <vector>
+
+#include <libff/algebra/curves/bn128/bn128_pp.hpp>
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/common/rng.hpp>
+
+#define INSTANCE_SIZE 10000
+#define INSTANCE_COUNT 10
+
+using namespace libff;
+
+template<typename GroupT, typename FieldT>
+void profile_multiexp()
+{
+    std::vector<std::vector<GroupT> > group_elements(INSTANCE_COUNT);
+    std::vector<std::vector<FieldT> > scalars(INSTANCE_COUNT);
+
+    enter_block("Generating test data");
+    for (int i = 0; i < INSTANCE_COUNT; i++) {
+        GroupT x = GroupT::random_element();
+        for (int j = 0; j < INSTANCE_SIZE; j++) {
+            group_elements[i].push_back(x);
+            scalars[i].push_back(SHA512_rng<FieldT>(i * INSTANCE_SIZE + j));
+        }
+    }
+    leave_block("Generating test data");
+
+
+    enter_block("Running naive_exp");
+    std::vector<GroupT> naive_answers;
+    for (int i = 0; i < INSTANCE_COUNT; i++) {
+        naive_answers.push_back(multi_exp<GroupT, FieldT>(
+            group_elements[i].cbegin(), group_elements[i].cend(),
+            scalars[i].cbegin(), scalars[i].cend(),
+            1, false));
+    }
+    leave_block("Running naive_exp");
+
+    enter_block("Running multi_exp");
+    std::vector<GroupT> multiexp_answers;
+    for (int i = 0; i < INSTANCE_COUNT; i++) {
+        multiexp_answers.push_back(multi_exp<GroupT, FieldT>(
+            group_elements[i].cbegin(), group_elements[i].cend(),
+            scalars[i].cbegin(), scalars[i].cend(),
+            1, true));
+    }
+    leave_block("Running multi_exp");
+
+    bool answers_correct = true;
+    for (int i = 0; i < INSTANCE_COUNT; i++) {
+        answers_correct = answers_correct &&
+            (naive_answers[i] == multiexp_answers[i]);
+    }
+
+    if (answers_correct) {
+        printf("Answers correct\n");
+    } else {
+        printf("!!!!!!!!!!!!!!!!!\n");
+        printf("Answers INCORRECT\n");
+        printf("!!!!!!!!!!!!!!!!!\n");
+    }
+}
+
+int main(void)
+{
+    print_compilation_info();
+    start_profiling();
+
+    printf("Using %d instances of size %d each\n", INSTANCE_COUNT, INSTANCE_SIZE);
+
+    printf("Profiling BN128_G1\n");
+    bn128_pp::init_public_params();
+    profile_multiexp<G1<bn128_pp>, Fr<bn128_pp> >();
+
+    return 0;
+}


### PR DESCRIPTION
The main purpose of this pull request is to improve multiexponentiation performance.

To this end, the pull request replaces the old `bool use_multiexp` parameter in the `multi_exp` function (and related ones, such as `multi_exp_with_mixed_addition`) with a template parameter `Method` that can be used to select one of many algorithms. The short version of the justification for why this parameter must be a template parameter is that some algorithms do not compile with some choices of operand type --- e.g., the method previously implemented in `naive_exp` uses `opt_window_wnaf_exp`, so it wouldn't compile for any type `opt_window_wnaf_exp` doesn't support.

The most exciting part of this pull request is the introduction of the `multi_exp_method_djb` algorithm, an implementation of the special case of Pippenger's algorithm as presented by [Dan Bernstein et al](https://eprint.iacr.org/2012/549.pdf) (p. 15). We have found that this algorithm significantly outperforms our existing implementation of the Bos-Coster algorithm on big, random inputs. 

Specifically, on a machine with an `Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz` CPU, when compiling libff with `MULTICORE=off` and `USE_MIXED_ADDITION=on` and exponentiating members of `BN128_G1`, djb is **32% faster on 2^18 inputs**, and **47% faster on 2^22 inputs**.

Further performance improvements might be possible by tuning the `c` parameter in the implementation of djb. It appears that optimal selection of this parameter might be machine-specific, much like the window sizes for `fixed_base_exp_window_table`.

This change breaks libsnark by changing the signature of the `multi_exp` function; a libsnark pull request adopting to this change and also switching to using the djb algorithm where useful is coming in a moment.