### PR TITLE
CMake: Drop support for OPT_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 project (libff)
 
+# Default to RelWithDebInfo configuration if no configuration is explicitly specified.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type on single-configuration generators" FORCE)
+endif()
+
 set(
   CURVE
   "BN128"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,14 +81,6 @@ option(
   ON
 )
 
-set(
-  OPT_FLAGS
-  ""
-  CACHE
-  STRING
-  "Override C++ compiler optimization flags"
-)
-
 if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # Common compilation flags and warning configuration
   set(
@@ -98,19 +90,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   if("${MULTICORE}")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
   endif()
-  # Default optimizations flags (to override, use -DOPT_FLAGS=...)
-  if("${OPT_FLAGS}" STREQUAL "")
-    set(
-      OPT_FLAGS
-      "-ggdb3 -O2 -march=native -mtune=native"
-    )
-  endif()
 endif()
-
-set(
-  CMAKE_CXX_FLAGS
-  "${CMAKE_CXX_FLAGS} ${OPT_FLAGS}"
-)
 
 find_path(GMP_INCLUDE_DIR NAMES gmp.h)
 find_library(GMP_LIBRARY gmp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,9 +107,8 @@ set_target_properties(
   INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
 )
 
-include(FindPkgConfig)
-
 if("${WITH_PROCPS}")
+  include(FindPkgConfig)
   pkg_check_modules(
     PROCPS
     REQUIRED


### PR DESCRIPTION
1. Adding -march=native flag by default is bad idea, because this makes the library not portable.
2. If you want to optimize with -march=native just do
```
cmake -DCMAKE_CXX_FLAGS='-march=native -mtune=native'
```