### PR TITLE
Fix curves interfaces inconsistencies

### DIFF
--- a/libff/algebra/curves/bn128/bn128_g1.cpp
+++ b/libff/algebra/curves/bn128/bn128_g1.cpp
@@ -72,9 +72,9 @@ bn::Fp bn128_G1::sqrt(const bn::Fp &el)
 
 bn128_G1::bn128_G1()
 {
-    this->coord[0] = G1_zero.coord[0];
-    this->coord[1] = G1_zero.coord[1];
-    this->coord[2] = G1_zero.coord[2];
+    this->X = G1_zero.X;
+    this->Y = G1_zero.Y;
+    this->Z = G1_zero.Z;
 }
 
 void bn128_G1::print() const
@@ -87,7 +87,7 @@ void bn128_G1::print() const
     {
         bn128_G1 copy(*this);
         copy.to_affine_coordinates();
-        std::cout << "(" << copy.coord[0].toString(10) << " : " << copy.coord[1].toString(10) << " : " << copy.coord[2].toString(10) << ")\n";
+        std::cout << "(" << copy.X.toString(10) << " : " << copy.Y.toString(10) << " : " << copy.Z.toString(10) << ")\n";
     }
 }
 
@@ -99,7 +99,7 @@ void bn128_G1::print_coordinates() const
     }
     else
     {
-        std::cout << "(" << coord[0].toString(10) << " : " << coord[1].toString(10) << " : " << coord[2].toString(10) << ")\n";
+        std::cout << "(" << X.toString(10) << " : " << Y.toString(10) << " : " << Z.toString(10) << ")\n";
     }
 }
 
@@ -107,20 +107,20 @@ void bn128_G1::to_affine_coordinates()
 {
     if (this->is_zero())
     {
-        coord[0] = 0;
-        coord[1] = 1;
-        coord[2] = 0;
+        X = 0;
+        Y = 1;
+        Z = 0;
     }
     else
     {
         bn::Fp r;
-        r = coord[2];
+        r = Z;
         r.inverse();
-        bn::Fp::square(coord[2], r);
-        coord[0] *= coord[2];
-        r *= coord[2];
-        coord[1] *= r;
-        coord[2] = 1;
+        bn::Fp::square(Z, r);
+        X *= Z;
+        r *= Z;
+        Y *= r;
+        Z = 1;
     }
 }
 
@@ -131,12 +131,12 @@ void bn128_G1::to_special()
 
 bool bn128_G1::is_special() const
 {
-    return (this->is_zero() || this->coord[2] == 1);
+    return (this->is_zero() || this->Z == 1);
 }
 
 bool bn128_G1::is_zero() const
 {
-    return coord[2].isZero();
+    return Z.isZero();
 }
 
 bool bn128_G1::operator==(const bn128_G1 &other) const
@@ -154,10 +154,10 @@ bool bn128_G1::operator==(const bn128_G1 &other) const
     /* now neither is O */
 
     bn::Fp Z1sq, Z2sq, lhs, rhs;
-    bn::Fp::square(Z1sq, this->coord[2]);
-    bn::Fp::square(Z2sq, other.coord[2]);
-    bn::Fp::mul(lhs, Z2sq, this->coord[0]);
-    bn::Fp::mul(rhs, Z1sq, other.coord[0]);
+    bn::Fp::square(Z1sq, this->Z);
+    bn::Fp::square(Z2sq, other.Z);
+    bn::Fp::mul(lhs, Z2sq, this->X);
+    bn::Fp::mul(rhs, Z1sq, other.X);
 
     if (lhs != rhs)
     {
@@ -165,10 +165,10 @@ bool bn128_G1::operator==(const bn128_G1 &other) const
     }
 
     bn::Fp Z1cubed, Z2cubed;
-    bn::Fp::mul(Z1cubed, Z1sq, this->coord[2]);
-    bn::Fp::mul(Z2cubed, Z2sq, other.coord[2]);
-    bn::Fp::mul(lhs, Z2cubed, this->coord[1]);
-    bn::Fp::mul(rhs, Z1cubed, other.coord[1]);
+    bn::Fp::mul(Z1cubed, Z1sq, this->Z);
+    bn::Fp::mul(Z2cubed, Z2sq, other.Z);
+    bn::Fp::mul(lhs, Z2cubed, this->Y);
+    bn::Fp::mul(rhs, Z1cubed, other.Y);
 
     return (lhs == rhs);
 }
@@ -208,7 +208,7 @@ bn128_G1 bn128_G1::operator+(const bn128_G1 &other) const
 bn128_G1 bn128_G1::operator-() const
 {
     bn128_G1 result(*this);
-    bn::Fp::neg(result.coord[1], result.coord[1]);
+    bn::Fp::neg(result.Y, result.Y);
     return result;
 }
 
@@ -223,8 +223,12 @@ bn128_G1 bn128_G1::add(const bn128_G1 &other) const
     this->add_cnt++;
 #endif
 
-    bn128_G1 result;
-    bn::ecop::ECAdd(result.coord, this->coord, other.coord);
+    bn::Fp this_coord[3], other_coord[3], result_coord[3];
+    this->fill_coord(&this_coord);
+    other.fill_coord(&other_coord);
+    bn::ecop::ECAdd(result_coord, this_coord, other_coord);
+    
+    bn128_G1 result(result_coord);
     return result;
 }
 
@@ -259,16 +263,16 @@ bn128_G1 bn128_G1::mixed_add(const bn128_G1 &other) const
     // we know that Z2 = 1
 
     bn::Fp Z1Z1;
-    bn::Fp::square(Z1Z1, this->coord[2]);
-    const bn::Fp &U1 = this->coord[0];
+    bn::Fp::square(Z1Z1, this->Z);
+    const bn::Fp &U1 = this->X;
     bn::Fp U2;
-    bn::Fp::mul(U2, other.coord[0], Z1Z1);
+    bn::Fp::mul(U2, other.X, Z1Z1);
     bn::Fp Z1_cubed;
-    bn::Fp::mul(Z1_cubed, this->coord[2], Z1Z1);
+    bn::Fp::mul(Z1_cubed, this->Z, Z1Z1);
 
-    const bn::Fp &S1 = this->coord[1];
+    const bn::Fp &S1 = this->Y;
     bn::Fp S2;
-    bn::Fp::mul(S2, other.coord[1], Z1_cubed); // S2 = Y2*Z1*Z1Z1
+    bn::Fp::mul(S2, other.Y, Z1_cubed); // S2 = Y2*Z1*Z1Z1
 
     if (U1 == U2 && S1 == S2)
     {
@@ -283,7 +287,7 @@ bn128_G1 bn128_G1::mixed_add(const bn128_G1 &other) const
     bn128_G1 result;
     bn::Fp H, HH, I, J, r, V, tmp;
     // H = U2-X1
-    bn::Fp::sub(H, U2, this->coord[0]);
+    bn::Fp::sub(H, U2, this->X);
     // HH = H^2
     bn::Fp::square(HH, H);
     // I = 4*HH
@@ -292,26 +296,26 @@ bn128_G1 bn128_G1::mixed_add(const bn128_G1 &other) const
     // J = H*I
     bn::Fp::mul(J, H, I);
     // r = 2*(S2-Y1)
-    bn::Fp::sub(tmp, S2, this->coord[1]);
+    bn::Fp::sub(tmp, S2, this->Y);
     bn::Fp::add(r, tmp, tmp);
     // V = X1*I
-    bn::Fp::mul(V, this->coord[0], I);
+    bn::Fp::mul(V, this->X, I);
     // X3 = r^2-J-2*V
-    bn::Fp::square(result.coord[0], r);
-    bn::Fp::sub(result.coord[0], result.coord[0], J);
-    bn::Fp::sub(result.coord[0], result.coord[0], V);
-    bn::Fp::sub(result.coord[0], result.coord[0], V);
+    bn::Fp::square(result.X, r);
+    bn::Fp::sub(result.X, result.X, J);
+    bn::Fp::sub(result.X, result.X, V);
+    bn::Fp::sub(result.X, result.X, V);
     // Y3 = r*(V-X3)-2*Y1*J
-    bn::Fp::sub(tmp, V, result.coord[0]);
-    bn::Fp::mul(result.coord[1], r, tmp);
-    bn::Fp::mul(tmp, this->coord[1], J);
-    bn::Fp::sub(result.coord[1], result.coord[1], tmp);
-    bn::Fp::sub(result.coord[1], result.coord[1], tmp);
+    bn::Fp::sub(tmp, V, result.X);
+    bn::Fp::mul(result.Y, r, tmp);
+    bn::Fp::mul(tmp, this->Y, J);
+    bn::Fp::sub(result.Y, result.Y, tmp);
+    bn::Fp::sub(result.Y, result.Y, tmp);
     // Z3 = (Z1+H)^2-Z1Z1-HH
-    bn::Fp::add(tmp, this->coord[2], H);
-    bn::Fp::square(result.coord[2], tmp);
-    bn::Fp::sub(result.coord[2], result.coord[2], Z1Z1);
-    bn::Fp::sub(result.coord[2], result.coord[2], HH);
+    bn::Fp::add(tmp, this->Z, H);
+    bn::Fp::square(result.Z, tmp);
+    bn::Fp::sub(result.Z, result.Z, Z1Z1);
+    bn::Fp::sub(result.Z, result.Z, HH);
     return result;
 }
 
@@ -321,8 +325,11 @@ bn128_G1 bn128_G1::dbl() const
     this->dbl_cnt++;
 #endif
 
-    bn128_G1 result;
-    bn::ecop::ECDouble(result.coord, this->coord);
+    bn::Fp this_coord[3], result_coord[3];
+    this->fill_coord(&this_coord);
+    bn::ecop::ECDouble(result_coord, this_coord);
+
+    bn128_G1 result(result_coord);
     return result;
 }
 
@@ -351,20 +358,20 @@ std::ostream& operator<<(std::ostream &out, const bn128_G1 &g)
 #ifdef NO_PT_COMPRESSION
     /* no point compression case */
 #ifndef BINARY_OUTPUT
-    out << gcopy.coord[0] << OUTPUT_SEPARATOR << gcopy.coord[1];
+    out << gcopy.X << OUTPUT_SEPARATOR << gcopy.Y;
 #else
-    out.write((char*) &gcopy.coord[0], sizeof(gcopy.coord[0]));
-    out.write((char*) &gcopy.coord[1], sizeof(gcopy.coord[1]));
+    out.write((char*) &gcopy.X, sizeof(gcopy.X));
+    out.write((char*) &gcopy.Y, sizeof(gcopy.Y));
 #endif
 
 #else
     /* point compression case */
 #ifndef BINARY_OUTPUT
-    out << gcopy.coord[0];
+    out << gcopy.X;
 #else
-    out.write((char*) &gcopy.coord[0], sizeof(gcopy.coord[0]));
+    out.write((char*) &gcopy.X, sizeof(gcopy.X));
 #endif
-    out << OUTPUT_SEPARATOR << (((unsigned char*)&gcopy.coord[1])[0] & 1 ? '1' : '0');
+    out << OUTPUT_SEPARATOR << (((unsigned char*)&gcopy.Y)[0] & 1 ? '1' : '0');
 #endif
 
     return out;
@@ -388,13 +395,13 @@ bool bn128_G1::is_well_formed() const
           y^2 = x^3 + b z^6
         */
         bn::Fp X2, Y2, Z2;
-        bn::Fp::square(X2, this->coord[0]);
-        bn::Fp::square(Y2, this->coord[1]);
-        bn::Fp::square(Z2, this->coord[2]);
+        bn::Fp::square(X2, this->X);
+        bn::Fp::square(Y2, this->Y);
+        bn::Fp::square(Z2, this->Z);
 
         bn::Fp X3, Z3, Z6;
-        bn::Fp::mul(X3, X2, this->coord[0]);
-        bn::Fp::mul(Z3, Z2, this->coord[2]);
+        bn::Fp::mul(X3, X2, this->X);
+        bn::Fp::mul(Z3, Z2, this->Z);
         bn::Fp::square(Z6, Z3);
 
         return (Y2 == X3 + bn128_coeff_b * Z6);
@@ -411,12 +418,12 @@ std::istream& operator>>(std::istream &in, bn128_G1 &g)
 #ifdef NO_PT_COMPRESSION
     /* no point compression case */
 #ifndef BINARY_OUTPUT
-    in >> g.coord[0];
+    in >> g.X;
     consume_OUTPUT_SEPARATOR(in);
-    in >> g.coord[1];
+    in >> g.Y;
 #else
-    in.read((char*) &g.coord[0], sizeof(g.coord[0]));
-    in.read((char*) &g.coord[1], sizeof(g.coord[1]));
+    in.read((char*) &g.X, sizeof(g.X));
+    in.read((char*) &g.Y, sizeof(g.Y));
 #endif
 
 #else
@@ -435,16 +442,16 @@ std::istream& operator>>(std::istream &in, bn128_G1 &g)
     // y = +/- sqrt(x^3 + b)
     if (!is_zero)
     {
-        g.coord[0] = tX;
+        g.X = tX;
         bn::Fp tX2, tY2;
         bn::Fp::square(tX2, tX);
         bn::Fp::mul(tY2, tX2, tX);
         bn::Fp::add(tY2, tY2, bn128_coeff_b);
 
-        g.coord[1] = bn128_G1::sqrt(tY2);
-        if ((((unsigned char*)&g.coord[1])[0] & 1) != Y_lsb)
+        g.Y = bn128_G1::sqrt(tY2);
+        if ((((unsigned char*)&g.Y)[0] & 1) != Y_lsb)
         {
-            bn::Fp::neg(g.coord[1], g.coord[1]);
+            bn::Fp::neg(g.Y, g.Y);
         }
     }
 #endif
@@ -452,7 +459,7 @@ std::istream& operator>>(std::istream &in, bn128_G1 &g)
     /* finalize */
     if (!is_zero)
     {
-        g.coord[2] = bn::Fp(1);
+        g.Z = bn::Fp(1);
     }
     else
     {
@@ -498,7 +505,7 @@ void bn128_G1::batch_to_special_all_non_zeros(std::vector<bn128_G1> &vec)
 
     for (auto &el: vec)
     {
-        Z_vec.emplace_back(el.coord[2]);
+        Z_vec.emplace_back(el.Z);
     }
     bn_batch_invert<bn::Fp>(Z_vec);
 
@@ -510,9 +517,9 @@ void bn128_G1::batch_to_special_all_non_zeros(std::vector<bn128_G1> &vec)
         bn::Fp::square(Z2, Z_vec[i]);
         bn::Fp::mul(Z3, Z2, Z_vec[i]);
 
-        bn::Fp::mul(vec[i].coord[0], vec[i].coord[0], Z2);
-        bn::Fp::mul(vec[i].coord[1], vec[i].coord[1], Z3);
-        vec[i].coord[2] = one;
+        bn::Fp::mul(vec[i].X, vec[i].X, Z2);
+        bn::Fp::mul(vec[i].Y, vec[i].Y, Z3);
+        vec[i].Z = one;
     }
 }
 

--- a/libff/algebra/curves/bn128/bn128_g1.cpp
+++ b/libff/algebra/curves/bn128/bn128_g1.cpp
@@ -224,10 +224,10 @@ bn128_G1 bn128_G1::add(const bn128_G1 &other) const
 #endif
 
     bn::Fp this_coord[3], other_coord[3], result_coord[3];
-    this->fill_coord(&this_coord);
-    other.fill_coord(&other_coord);
+    this->fill_coord(this_coord);
+    other.fill_coord(other_coord);
     bn::ecop::ECAdd(result_coord, this_coord, other_coord);
-    
+
     bn128_G1 result(result_coord);
     return result;
 }
@@ -326,7 +326,7 @@ bn128_G1 bn128_G1::dbl() const
 #endif
 
     bn::Fp this_coord[3], result_coord[3];
-    this->fill_coord(&this_coord);
+    this->fill_coord(this_coord);
     bn::ecop::ECDouble(result_coord, this_coord);
 
     bn128_G1 result(result_coord);

--- a/libff/algebra/curves/bn128/bn128_g1.hpp
+++ b/libff/algebra/curves/bn128/bn128_g1.hpp
@@ -33,10 +33,14 @@ public:
     static bn128_G1 G1_zero;
     static bn128_G1 G1_one;
 
-    bn::Fp coord[3];
-    bn128_G1();
     typedef bn128_Fq base_field;
     typedef bn128_Fr scalar_field;
+
+    bn::Fp X, Y, Z;
+    void fill_coord(bn::Fp (*coord)[3]) const { (*coord)[0] = this->X; (*coord)[1] = this->Y; (*coord)[2] = this->Z; return; };
+
+    bn128_G1();
+    bn128_G1(bn::Fp coord[3]) : X(coord[0]), Y(coord[1]), Z(coord[2]) {};
 
     void print() const;
     void print_coordinates() const;

--- a/libff/algebra/curves/bn128/bn128_g1.hpp
+++ b/libff/algebra/curves/bn128/bn128_g1.hpp
@@ -37,7 +37,7 @@ public:
     typedef bn128_Fr scalar_field;
 
     bn::Fp X, Y, Z;
-    void fill_coord(bn::Fp (*coord)[3]) const { (*coord)[0] = this->X; (*coord)[1] = this->Y; (*coord)[2] = this->Z; return; };
+    void fill_coord(bn::Fp coord[3]) const { coord[0] = this->X; coord[1] = this->Y; coord[2] = this->Z; return; };
 
     bn128_G1();
     bn128_G1(bn::Fp coord[3]) : X(coord[0]), Y(coord[1]), Z(coord[2]) {};

--- a/libff/algebra/curves/bn128/bn128_g2.cpp
+++ b/libff/algebra/curves/bn128/bn128_g2.cpp
@@ -224,8 +224,8 @@ bn128_G2 bn128_G2::add(const bn128_G2 &other) const
 #endif
 
     bn::Fp2 this_coord[3], other_coord[3], result_coord[3];
-    this->fill_coord(&this_coord);
-    other.fill_coord(&other_coord);
+    this->fill_coord(this_coord);
+    other.fill_coord(other_coord);
     bn::ecop::ECAdd(result_coord, this_coord, other_coord);
 
     bn128_G2 result(result_coord);
@@ -326,7 +326,7 @@ bn128_G2 bn128_G2::dbl() const
 #endif
 
     bn::Fp2 this_coord[3], result_coord[3];
-    this->fill_coord(&this_coord);
+    this->fill_coord(this_coord);
     bn::ecop::ECDouble(result_coord, this_coord);
 
     bn128_G2 result(result_coord);

--- a/libff/algebra/curves/bn128/bn128_g2.cpp
+++ b/libff/algebra/curves/bn128/bn128_g2.cpp
@@ -72,9 +72,9 @@ bn::Fp2 bn128_G2::sqrt(const bn::Fp2 &el)
 
 bn128_G2::bn128_G2()
 {
-    this->coord[0] = G2_zero.coord[0];
-    this->coord[1] = G2_zero.coord[1];
-    this->coord[2] = G2_zero.coord[2];
+    this->X = G2_zero.X;
+    this->Y = G2_zero.Y;
+    this->Z = G2_zero.Z;
 }
 
 void bn128_G2::print() const
@@ -87,7 +87,7 @@ void bn128_G2::print() const
     {
         bn128_G2 copy(*this);
         copy.to_affine_coordinates();
-        std::cout << "(" << copy.coord[0].toString(10) << " : " << copy.coord[1].toString(10) << " : " << copy.coord[2].toString(10) << ")\n";
+        std::cout << "(" << copy.X.toString(10) << " : " << copy.Y.toString(10) << " : " << copy.Z.toString(10) << ")\n";
     }
 }
 
@@ -99,7 +99,7 @@ void bn128_G2::print_coordinates() const
     }
     else
     {
-        std::cout << "(" << coord[0].toString(10) << " : " << coord[1].toString(10) << " : " << coord[2].toString(10) << ")\n";
+        std::cout << "(" << X.toString(10) << " : " << Y.toString(10) << " : " << Z.toString(10) << ")\n";
     }
 }
 
@@ -107,20 +107,20 @@ void bn128_G2::to_affine_coordinates()
 {
     if (this->is_zero())
     {
-        coord[0] = 0;
-        coord[1] = 1;
-        coord[2] = 0;
+        X = 0;
+        Y = 1;
+        Z = 0;
     }
     else
     {
         bn::Fp2 r;
-        r = coord[2];
+        r = Z;
         r.inverse();
-        bn::Fp2::square(coord[2], r);
-        coord[0] *= coord[2];
-        r *= coord[2];
-        coord[1] *= r;
-        coord[2] = 1;
+        bn::Fp2::square(Z, r);
+        X *= Z;
+        r *= Z;
+        Y *= r;
+        Z = 1;
     }
 }
 
@@ -131,12 +131,12 @@ void bn128_G2::to_special()
 
 bool bn128_G2::is_special() const
 {
-    return (this->is_zero() || this->coord[2] == 1);
+    return (this->is_zero() || this->Z == 1);
 }
 
 bool bn128_G2::is_zero() const
 {
-    return coord[2].isZero();
+    return Z.isZero();
 }
 
 bool bn128_G2::operator==(const bn128_G2 &other) const
@@ -154,10 +154,10 @@ bool bn128_G2::operator==(const bn128_G2 &other) const
     /* now neither is O */
 
     bn::Fp2 Z1sq, Z2sq, lhs, rhs;
-    bn::Fp2::square(Z1sq, this->coord[2]);
-    bn::Fp2::square(Z2sq, other.coord[2]);
-    bn::Fp2::mul(lhs, Z2sq, this->coord[0]);
-    bn::Fp2::mul(rhs, Z1sq, other.coord[0]);
+    bn::Fp2::square(Z1sq, this->Z);
+    bn::Fp2::square(Z2sq, other.Z);
+    bn::Fp2::mul(lhs, Z2sq, this->X);
+    bn::Fp2::mul(rhs, Z1sq, other.X);
 
     if (lhs != rhs)
     {
@@ -165,10 +165,10 @@ bool bn128_G2::operator==(const bn128_G2 &other) const
     }
 
     bn::Fp2 Z1cubed, Z2cubed;
-    bn::Fp2::mul(Z1cubed, Z1sq, this->coord[2]);
-    bn::Fp2::mul(Z2cubed, Z2sq, other.coord[2]);
-    bn::Fp2::mul(lhs, Z2cubed, this->coord[1]);
-    bn::Fp2::mul(rhs, Z1cubed, other.coord[1]);
+    bn::Fp2::mul(Z1cubed, Z1sq, this->Z);
+    bn::Fp2::mul(Z2cubed, Z2sq, other.Z);
+    bn::Fp2::mul(lhs, Z2cubed, this->Y);
+    bn::Fp2::mul(rhs, Z1cubed, other.Y);
 
     return (lhs == rhs);
 }
@@ -208,7 +208,7 @@ bn128_G2 bn128_G2::operator+(const bn128_G2 &other) const
 bn128_G2 bn128_G2::operator-() const
 {
     bn128_G2 result(*this);
-    bn::Fp2::neg(result.coord[1], result.coord[1]);
+    bn::Fp2::neg(result.Y, result.Y);
     return result;
 }
 
@@ -223,8 +223,12 @@ bn128_G2 bn128_G2::add(const bn128_G2 &other) const
     this->add_cnt++;
 #endif
 
-    bn128_G2 result;
-    bn::ecop::ECAdd(result.coord, this->coord, other.coord);
+    bn::Fp2 this_coord[3], other_coord[3], result_coord[3];
+    this->fill_coord(&this_coord);
+    other.fill_coord(&other_coord);
+    bn::ecop::ECAdd(result_coord, this_coord, other_coord);
+
+    bn128_G2 result(result_coord);
     return result;
 }
 
@@ -259,16 +263,16 @@ bn128_G2 bn128_G2::mixed_add(const bn128_G2 &other) const
     // we know that Z2 = 1
 
     bn::Fp2 Z1Z1;
-    bn::Fp2::square(Z1Z1, this->coord[2]);
-    const bn::Fp2 &U1 = this->coord[0];
+    bn::Fp2::square(Z1Z1, this->Z);
+    const bn::Fp2 &U1 = this->X;
     bn::Fp2 U2;
-    bn::Fp2::mul(U2, other.coord[0], Z1Z1);
+    bn::Fp2::mul(U2, other.X, Z1Z1);
     bn::Fp2 Z1_cubed;
-    bn::Fp2::mul(Z1_cubed, this->coord[2], Z1Z1);
+    bn::Fp2::mul(Z1_cubed, this->Z, Z1Z1);
 
-    const bn::Fp2 &S1 = this->coord[1];
+    const bn::Fp2 &S1 = this->Y;
     bn::Fp2 S2;
-    bn::Fp2::mul(S2, other.coord[1], Z1_cubed); // S2 = Y2*Z1*Z1Z1
+    bn::Fp2::mul(S2, other.Y, Z1_cubed); // S2 = Y2*Z1*Z1Z1
 
     if (U1 == U2 && S1 == S2)
     {
@@ -283,7 +287,7 @@ bn128_G2 bn128_G2::mixed_add(const bn128_G2 &other) const
     bn128_G2 result;
     bn::Fp2 H, HH, I, J, r, V, tmp;
     // H = U2-X1
-    bn::Fp2::sub(H, U2, this->coord[0]);
+    bn::Fp2::sub(H, U2, this->X);
     // HH = H^2
     bn::Fp2::square(HH, H);
     // I = 4*HH
@@ -292,26 +296,26 @@ bn128_G2 bn128_G2::mixed_add(const bn128_G2 &other) const
     // J = H*I
     bn::Fp2::mul(J, H, I);
     // r = 2*(S2-Y1)
-    bn::Fp2::sub(tmp, S2, this->coord[1]);
+    bn::Fp2::sub(tmp, S2, this->Y);
     bn::Fp2::add(r, tmp, tmp);
     // V = X1*I
-    bn::Fp2::mul(V, this->coord[0], I);
+    bn::Fp2::mul(V, this->X, I);
     // X3 = r^2-J-2*V
-    bn::Fp2::square(result.coord[0], r);
-    bn::Fp2::sub(result.coord[0], result.coord[0], J);
-    bn::Fp2::sub(result.coord[0], result.coord[0], V);
-    bn::Fp2::sub(result.coord[0], result.coord[0], V);
+    bn::Fp2::square(result.X, r);
+    bn::Fp2::sub(result.X, result.X, J);
+    bn::Fp2::sub(result.X, result.X, V);
+    bn::Fp2::sub(result.X, result.X, V);
     // Y3 = r*(V-X3)-2*Y1*J
-    bn::Fp2::sub(tmp, V, result.coord[0]);
-    bn::Fp2::mul(result.coord[1], r, tmp);
-    bn::Fp2::mul(tmp, this->coord[1], J);
-    bn::Fp2::sub(result.coord[1], result.coord[1], tmp);
-    bn::Fp2::sub(result.coord[1], result.coord[1], tmp);
+    bn::Fp2::sub(tmp, V, result.X);
+    bn::Fp2::mul(result.Y, r, tmp);
+    bn::Fp2::mul(tmp, this->Y, J);
+    bn::Fp2::sub(result.Y, result.Y, tmp);
+    bn::Fp2::sub(result.Y, result.Y, tmp);
     // Z3 = (Z1+H)^2-Z1Z1-HH
-    bn::Fp2::add(tmp, this->coord[2], H);
-    bn::Fp2::square(result.coord[2], tmp);
-    bn::Fp2::sub(result.coord[2], result.coord[2], Z1Z1);
-    bn::Fp2::sub(result.coord[2], result.coord[2], HH);
+    bn::Fp2::add(tmp, this->Z, H);
+    bn::Fp2::square(result.Z, tmp);
+    bn::Fp2::sub(result.Z, result.Z, Z1Z1);
+    bn::Fp2::sub(result.Z, result.Z, HH);
     return result;
 }
 
@@ -320,8 +324,12 @@ bn128_G2 bn128_G2::dbl() const
 #ifdef PROFILE_OP_COUNTS
     this->dbl_cnt++;
 #endif
-    bn128_G2 result;
-    bn::ecop::ECDouble(result.coord, this->coord);
+
+    bn::Fp2 this_coord[3], result_coord[3];
+    this->fill_coord(&this_coord);
+    bn::ecop::ECDouble(result_coord, this_coord);
+
+    bn128_G2 result(result_coord);
     return result;
 }
 
@@ -343,13 +351,13 @@ bool bn128_G2::is_well_formed() const
           y^2 = x^3 + b z^6
         */
         bn::Fp2 X2, Y2, Z2;
-        bn::Fp2::square(X2, this->coord[0]);
-        bn::Fp2::square(Y2, this->coord[1]);
-        bn::Fp2::square(Z2, this->coord[2]);
+        bn::Fp2::square(X2, this->X);
+        bn::Fp2::square(Y2, this->Y);
+        bn::Fp2::square(Z2, this->Z);
 
         bn::Fp2 X3, Z3, Z6;
-        bn::Fp2::mul(X3, X2, this->coord[0]);
-        bn::Fp2::mul(Z3, Z2, this->coord[2]);
+        bn::Fp2::mul(X3, X2, this->X);
+        bn::Fp2::mul(Z3, Z2, this->Z);
         bn::Fp2::square(Z6, Z3);
 
         return (Y2 == X3 + bn128_twist_coeff_b * Z6);
@@ -381,24 +389,24 @@ std::ostream& operator<<(std::ostream &out, const bn128_G2 &g)
 #ifdef NO_PT_COMPRESSION
     /* no point compression case */
 #ifndef BINARY_OUTPUT
-    out << gcopy.coord[0].a_ << OUTPUT_SEPARATOR << gcopy.coord[0].b_ << OUTPUT_SEPARATOR;
-    out << gcopy.coord[1].a_ << OUTPUT_SEPARATOR << gcopy.coord[1].b_;
+    out << gcopy.X.a_ << OUTPUT_SEPARATOR << gcopy.X.b_ << OUTPUT_SEPARATOR;
+    out << gcopy.Y.a_ << OUTPUT_SEPARATOR << gcopy.Y.b_;
 #else
-    out.write((char*) &gcopy.coord[0].a_, sizeof(gcopy.coord[0].a_));
-    out.write((char*) &gcopy.coord[0].b_, sizeof(gcopy.coord[0].b_));
-    out.write((char*) &gcopy.coord[1].a_, sizeof(gcopy.coord[1].a_));
-    out.write((char*) &gcopy.coord[1].b_, sizeof(gcopy.coord[1].b_));
+    out.write((char*) &gcopy.X.a_, sizeof(gcopy.X.a_));
+    out.write((char*) &gcopy.X.b_, sizeof(gcopy.X.b_));
+    out.write((char*) &gcopy.Y.a_, sizeof(gcopy.Y.a_));
+    out.write((char*) &gcopy.Y.b_, sizeof(gcopy.Y.b_));
 #endif
 
 #else
     /* point compression case */
 #ifndef BINARY_OUTPUT
-    out << gcopy.coord[0].a_ << OUTPUT_SEPARATOR << gcopy.coord[0].b_;
+    out << gcopy.X.a_ << OUTPUT_SEPARATOR << gcopy.X.b_;
 #else
-    out.write((char*) &gcopy.coord[0].a_, sizeof(gcopy.coord[0].a_));
-    out.write((char*) &gcopy.coord[0].b_, sizeof(gcopy.coord[0].b_));
+    out.write((char*) &gcopy.X.a_, sizeof(gcopy.X.a_));
+    out.write((char*) &gcopy.X.b_, sizeof(gcopy.X.b_));
 #endif
-    out << OUTPUT_SEPARATOR << (((unsigned char*)&gcopy.coord[1].a_)[0] & 1 ? '1' : '0');
+    out << OUTPUT_SEPARATOR << (((unsigned char*)&gcopy.Y.a_)[0] & 1 ? '1' : '0');
 #endif
 
     return out;
@@ -414,18 +422,18 @@ std::istream& operator>>(std::istream &in, bn128_G2 &g)
 #ifdef NO_PT_COMPRESSION
     /* no point compression case */
 #ifndef BINARY_OUTPUT
-    in >> g.coord[0].a_;
+    in >> g.X.a_;
     consume_OUTPUT_SEPARATOR(in);
-    in >> g.coord[0].b_;
+    in >> g.X.b_;
     consume_OUTPUT_SEPARATOR(in);
-    in >> g.coord[1].a_;
+    in >> g.Y.a_;
     consume_OUTPUT_SEPARATOR(in);
-    in >> g.coord[1].b_;
+    in >> g.Y.b_;
 #else
-    in.read((char*) &g.coord[0].a_, sizeof(g.coord[0].a_));
-    in.read((char*) &g.coord[0].b_, sizeof(g.coord[0].b_));
-    in.read((char*) &g.coord[1].a_, sizeof(g.coord[1].a_));
-    in.read((char*) &g.coord[1].b_, sizeof(g.coord[1].b_));
+    in.read((char*) &g.X.a_, sizeof(g.X.a_));
+    in.read((char*) &g.X.b_, sizeof(g.X.b_));
+    in.read((char*) &g.Y.a_, sizeof(g.Y.a_));
+    in.read((char*) &g.Y.b_, sizeof(g.Y.b_));
 #endif
 
 #else
@@ -447,16 +455,16 @@ std::istream& operator>>(std::istream &in, bn128_G2 &g)
     // y = +/- sqrt(x^3 + b)
     if (!is_zero)
     {
-        g.coord[0] = tX;
+        g.X = tX;
         bn::Fp2 tX2, tY2;
         bn::Fp2::square(tX2, tX);
         bn::Fp2::mul(tY2, tX2, tX);
         bn::Fp2::add(tY2, tY2, bn128_twist_coeff_b);
 
-        g.coord[1] = bn128_G2::sqrt(tY2);
-        if ((((unsigned char*)&g.coord[1].a_)[0] & 1) != Y_lsb)
+        g.Y = bn128_G2::sqrt(tY2);
+        if ((((unsigned char*)&g.Y.a_)[0] & 1) != Y_lsb)
         {
-            bn::Fp2::neg(g.coord[1], g.coord[1]);
+            bn::Fp2::neg(g.Y, g.Y);
         }
     }
 #endif
@@ -464,7 +472,7 @@ std::istream& operator>>(std::istream &in, bn128_G2 &g)
     /* finalize */
     if (!is_zero)
     {
-        g.coord[2] = bn::Fp2(bn::Fp(1), bn::Fp(0));
+        g.Z = bn::Fp2(bn::Fp(1), bn::Fp(0));
     }
     else
     {
@@ -481,7 +489,7 @@ void bn128_G2::batch_to_special_all_non_zeros(std::vector<bn128_G2> &vec)
 
     for (auto &el: vec)
     {
-        Z_vec.emplace_back(el.coord[2]);
+        Z_vec.emplace_back(el.Z);
     }
     bn_batch_invert<bn::Fp2>(Z_vec);
 
@@ -493,9 +501,9 @@ void bn128_G2::batch_to_special_all_non_zeros(std::vector<bn128_G2> &vec)
         bn::Fp2::square(Z2, Z_vec[i]);
         bn::Fp2::mul(Z3, Z2, Z_vec[i]);
 
-        bn::Fp2::mul(vec[i].coord[0], vec[i].coord[0], Z2);
-        bn::Fp2::mul(vec[i].coord[1], vec[i].coord[1], Z3);
-        vec[i].coord[2] = one;
+        bn::Fp2::mul(vec[i].X, vec[i].X, Z2);
+        bn::Fp2::mul(vec[i].Y, vec[i].Y, Z3);
+        vec[i].Z = one;
     }
 }
 

--- a/libff/algebra/curves/bn128/bn128_g2.hpp
+++ b/libff/algebra/curves/bn128/bn128_g2.hpp
@@ -38,7 +38,7 @@ public:
     typedef bn128_Fr scalar_field;
 
     bn::Fp2 X, Y, Z;
-    void fill_coord(bn::Fp2 (*coord)[3]) const { (*coord)[0] = this->X; (*coord)[1] = this->Y; (*coord)[2] = this->Z; };
+    void fill_coord(bn::Fp2 coord[3]) const { coord[0] = this->X; coord[1] = this->Y; coord[2] = this->Z; };
 
     bn128_G2();
     bn128_G2(bn::Fp2 coord[3]) : X(coord[0]), Y(coord[1]), Z(coord[2]) {};

--- a/libff/algebra/curves/bn128/bn128_g2.hpp
+++ b/libff/algebra/curves/bn128/bn128_g2.hpp
@@ -34,10 +34,14 @@ public:
     static bn128_G2 G2_zero;
     static bn128_G2 G2_one;
 
-    bn::Fp2 coord[3];
-    bn128_G2();
     typedef bn128_Fq base_field;
     typedef bn128_Fr scalar_field;
+
+    bn::Fp2 X, Y, Z;
+    void fill_coord(bn::Fp2 (*coord)[3]) const { (*coord)[0] = this->X; (*coord)[1] = this->Y; (*coord)[2] = this->Z; };
+
+    bn128_G2();
+    bn128_G2(bn::Fp2 coord[3]) : X(coord[0]), Y(coord[1]), Z(coord[2]) {};
 
     void print() const;
     void print_coordinates() const;

--- a/libff/algebra/curves/bn128/bn128_init.cpp
+++ b/libff/algebra/curves/bn128/bn128_init.cpp
@@ -98,13 +98,13 @@ void init_bn128_params()
     bn128_Fq2_t_minus_1_over_2 = mie::Vuint("14971724250519463826312126413021210649976634891596900701138993820439690427699319920245032869357433499099632259837909383182382988566862092145199781964621");
 
     /* choice of group G1 */
-    bn128_G1::G1_zero.coord[0] = bn::Fp(1);
-    bn128_G1::G1_zero.coord[1] = bn::Fp(1);
-    bn128_G1::G1_zero.coord[2] = bn::Fp(0);
+    bn128_G1::G1_zero.X = bn::Fp(1);
+    bn128_G1::G1_zero.Y = bn::Fp(1);
+    bn128_G1::G1_zero.Z = bn::Fp(0);
 
-    bn128_G1::G1_one.coord[0] = bn::Fp(1);
-    bn128_G1::G1_one.coord[1] = bn::Fp(2);
-    bn128_G1::G1_one.coord[2] = bn::Fp(1);
+    bn128_G1::G1_one.X = bn::Fp(1);
+    bn128_G1::G1_one.Y = bn::Fp(2);
+    bn128_G1::G1_one.Z = bn::Fp(1);
 
     bn128_G1::wnaf_window_table.resize(0);
     bn128_G1::wnaf_window_table.push_back(10);
@@ -159,15 +159,15 @@ void init_bn128_params()
     bn128_G1::fixed_base_exp_window_table.push_back(29482996);
 
     /* choice of group G2 */
-    bn128_G2::G2_zero.coord[0] = bn::Fp2(bn::Fp(1), bn::Fp(0));
-    bn128_G2::G2_zero.coord[1] = bn::Fp2(bn::Fp(1), bn::Fp(0));
-    bn128_G2::G2_zero.coord[2] = bn::Fp2(bn::Fp(0), bn::Fp(0));
+    bn128_G2::G2_zero.X = bn::Fp2(bn::Fp(1), bn::Fp(0));
+    bn128_G2::G2_zero.Y = bn::Fp2(bn::Fp(1), bn::Fp(0));
+    bn128_G2::G2_zero.Z = bn::Fp2(bn::Fp(0), bn::Fp(0));
 
-    bn128_G2::G2_one.coord[0] = bn::Fp2(bn::Fp("15267802884793550383558706039165621050290089775961208824303765753922461897946"),
+    bn128_G2::G2_one.X = bn::Fp2(bn::Fp("15267802884793550383558706039165621050290089775961208824303765753922461897946"),
                                         bn::Fp("9034493566019742339402378670461897774509967669562610788113215988055021632533"));
-    bn128_G2::G2_one.coord[1] = bn::Fp2(bn::Fp("644888581738283025171396578091639672120333224302184904896215738366765861164"),
+    bn128_G2::G2_one.Y = bn::Fp2(bn::Fp("644888581738283025171396578091639672120333224302184904896215738366765861164"),
                                         bn::Fp("20532875081203448695448744255224543661959516361327385779878476709582931298750"));
-    bn128_G2::G2_one.coord[2] = bn::Fp2(bn::Fp(1), bn::Fp(0));
+    bn128_G2::G2_one.Z = bn::Fp2(bn::Fp(1), bn::Fp(0));
 
     bn128_G2::wnaf_window_table.resize(0);
     bn128_G2::wnaf_window_table.push_back(7);

--- a/libff/algebra/curves/bn128/bn128_pairing.cpp
+++ b/libff/algebra/curves/bn128/bn128_pairing.cpp
@@ -166,7 +166,9 @@ bn128_ate_G1_precomp bn128_ate_precompute_G1(const bn128_G1& P)
     enter_block("Call to bn128_ate_precompute_G1");
 
     bn128_ate_G1_precomp result;
-    bn::ecop::NormalizeJac(result.P, P.coord);
+    bn::Fp P_coord[3];
+    P.fill_coord(&P_coord);
+    bn::ecop::NormalizeJac(result.P, P_coord);
 
     leave_block("Call to bn128_ate_precompute_G1");
     return result;
@@ -177,7 +179,9 @@ bn128_ate_G2_precomp bn128_ate_precompute_G2(const bn128_G2& Q)
     enter_block("Call to bn128_ate_precompute_G2");
 
     bn128_ate_G2_precomp result;
-    bn::components::precomputeG2(result.coeffs, result.Q, Q.coord);
+    bn::Fp2 Q_coord[3];
+    Q.fill_coord(&Q_coord);
+    bn::components::precomputeG2(result.coeffs, result.Q, Q_coord);
 
     leave_block("Call to bn128_ate_precompute_G2");
     return result;

--- a/libff/algebra/curves/bn128/bn128_pairing.cpp
+++ b/libff/algebra/curves/bn128/bn128_pairing.cpp
@@ -167,7 +167,7 @@ bn128_ate_G1_precomp bn128_ate_precompute_G1(const bn128_G1& P)
 
     bn128_ate_G1_precomp result;
     bn::Fp P_coord[3];
-    P.fill_coord(&P_coord);
+    P.fill_coord(P_coord);
     bn::ecop::NormalizeJac(result.P, P_coord);
 
     leave_block("Call to bn128_ate_precompute_G1");
@@ -180,7 +180,7 @@ bn128_ate_G2_precomp bn128_ate_precompute_G2(const bn128_G2& Q)
 
     bn128_ate_G2_precomp result;
     bn::Fp2 Q_coord[3];
-    Q.fill_coord(&Q_coord);
+    Q.fill_coord(Q_coord);
     bn::components::precomputeG2(result.coeffs, result.Q, Q_coord);
 
     leave_block("Call to bn128_ate_precompute_G2");

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g1.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g1.cpp
@@ -29,9 +29,9 @@ mnt4_Fq mnt4_G1::coeff_b;
 
 mnt4_G1::mnt4_G1()
 {
-    this->X_ = G1_zero.X_;
-    this->Y_ = G1_zero.Y_;
-    this->Z_ = G1_zero.Z_;
+    this->X = G1_zero.X;
+    this->Y = G1_zero.Y;
+    this->Z = G1_zero.Z;
 }
 
 void mnt4_G1::print() const
@@ -45,8 +45,8 @@ void mnt4_G1::print() const
         mnt4_G1 copy(*this);
         copy.to_affine_coordinates();
         gmp_printf("(%Nd , %Nd)\n",
-                   copy.X_.as_bigint().data, mnt4_Fq::num_limbs,
-                   copy.Y_.as_bigint().data, mnt4_Fq::num_limbs);
+                   copy.X.as_bigint().data, mnt4_Fq::num_limbs,
+                   copy.Y.as_bigint().data, mnt4_Fq::num_limbs);
     }
 }
 
@@ -59,9 +59,9 @@ void mnt4_G1::print_coordinates() const
     else
     {
         gmp_printf("(%Nd : %Nd : %Nd)\n",
-                   this->X_.as_bigint().data, mnt4_Fq::num_limbs,
-                   this->Y_.as_bigint().data, mnt4_Fq::num_limbs,
-                   this->Z_.as_bigint().data, mnt4_Fq::num_limbs);
+                   this->X.as_bigint().data, mnt4_Fq::num_limbs,
+                   this->Y.as_bigint().data, mnt4_Fq::num_limbs,
+                   this->Z.as_bigint().data, mnt4_Fq::num_limbs);
     }
 }
 
@@ -69,16 +69,16 @@ void mnt4_G1::to_affine_coordinates()
 {
     if (this->is_zero())
     {
-        this->X_ = mnt4_Fq::zero();
-        this->Y_ = mnt4_Fq::one();
-        this->Z_ = mnt4_Fq::zero();
+        this->X = mnt4_Fq::zero();
+        this->Y = mnt4_Fq::one();
+        this->Z = mnt4_Fq::zero();
     }
     else
     {
-        const mnt4_Fq Z_inv = Z_.inverse();
-        this->X_ = this->X_ * Z_inv;
-        this->Y_ = this->Y_ * Z_inv;
-        this->Z_ = mnt4_Fq::one();
+        const mnt4_Fq Z_inv = Z.inverse();
+        this->X = this->X * Z_inv;
+        this->Y = this->Y * Z_inv;
+        this->Z = mnt4_Fq::one();
     }
 }
 
@@ -89,12 +89,12 @@ void mnt4_G1::to_special()
 
 bool mnt4_G1::is_special() const
 {
-    return (this->is_zero() || this->Z_ == mnt4_Fq::one());
+    return (this->is_zero() || this->Z == mnt4_Fq::one());
 }
 
 bool mnt4_G1::is_zero() const
 {
-    return (this->X_.is_zero() && this->Z_.is_zero());
+    return (this->X.is_zero() && this->Z.is_zero());
 }
 
 bool mnt4_G1::operator==(const mnt4_G1 &other) const
@@ -112,13 +112,13 @@ bool mnt4_G1::operator==(const mnt4_G1 &other) const
     /* now neither is O */
 
     // X1/Z1 = X2/Z2 <=> X1*Z2 = X2*Z1
-    if ((this->X_ * other.Z_) != (other.X_ * this->Z_))
+    if ((this->X * other.Z) != (other.X * this->Z))
     {
         return false;
     }
 
     // Y1/Z1 = Y2/Z2 <=> Y1*Z2 = Y2*Z1
-    if ((this->Y_ * other.Z_) != (other.Y_ * this->Z_))
+    if ((this->Y * other.Z) != (other.Y * this->Z))
     {
         return false;
     }
@@ -161,27 +161,27 @@ mnt4_G1 mnt4_G1::operator+(const mnt4_G1 &other) const
       }
     */
 
-    const mnt4_Fq X1Z2 = (this->X_) * (other.Z_);        // X1Z2 = X1*Z2
-    const mnt4_Fq X2Z1 = (this->Z_) * (other.X_);        // X2Z1 = X2*Z1
+    const mnt4_Fq X1Z2 = (this->X) * (other.Z);        // X1Z2 = X1*Z2
+    const mnt4_Fq X2Z1 = (this->Z) * (other.X);        // X2Z1 = X2*Z1
 
     // (used both in add and double checks)
 
-    const mnt4_Fq Y1Z2 = (this->Y_) * (other.Z_);        // Y1Z2 = Y1*Z2
-    const mnt4_Fq Y2Z1 = (this->Z_) * (other.Y_);        // Y2Z1 = Y2*Z1
+    const mnt4_Fq Y1Z2 = (this->Y) * (other.Z);        // Y1Z2 = Y1*Z2
+    const mnt4_Fq Y2Z1 = (this->Z) * (other.Y);        // Y2Z1 = Y2*Z1
 
     if (X1Z2 == X2Z1 && Y1Z2 == Y2Z1)
     {
         // perform dbl case
-        const mnt4_Fq XX   = (this->X_).squared();                   // XX  = X1^2
-        const mnt4_Fq ZZ   = (this->Z_).squared();                   // ZZ  = Z1^2
+        const mnt4_Fq XX   = (this->X).squared();                   // XX  = X1^2
+        const mnt4_Fq ZZ   = (this->Z).squared();                   // ZZ  = Z1^2
         const mnt4_Fq w    = mnt4_G1::coeff_a * ZZ + (XX + XX + XX); // w   = a*ZZ + 3*XX
-        const mnt4_Fq Y1Z1 = (this->Y_) * (this->Z_);
+        const mnt4_Fq Y1Z1 = (this->Y) * (this->Z);
         const mnt4_Fq s    = Y1Z1 + Y1Z1;                            // s   = 2*Y1*Z1
         const mnt4_Fq ss   = s.squared();                            // ss  = s^2
         const mnt4_Fq sss  = s * ss;                                 // sss = s*ss
-        const mnt4_Fq R    = (this->Y_) * s;                         // R   = Y1*s
+        const mnt4_Fq R    = (this->Y) * s;                         // R   = Y1*s
         const mnt4_Fq RR   = R.squared();                            // RR  = R^2
-        const mnt4_Fq B    = ((this->X_)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
+        const mnt4_Fq B    = ((this->X)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
         const mnt4_Fq h    = w.squared() - (B+B);                    // h   = w^2 - 2*B
         const mnt4_Fq X3   = h * s;                                  // X3  = h*s
         const mnt4_Fq Y3   = w * (B-h)-(RR+RR);                      // Y3  = w*(B-h) - 2*RR
@@ -191,7 +191,7 @@ mnt4_G1 mnt4_G1::operator+(const mnt4_G1 &other) const
     }
 
     // if we have arrived here we are in the add case
-    const mnt4_Fq Z1Z2 = (this->Z_) * (other.Z_);        // Z1Z2 = Z1*Z2
+    const mnt4_Fq Z1Z2 = (this->Z) * (other.Z);        // Z1Z2 = Z1*Z2
     const mnt4_Fq u    = Y2Z1 - Y1Z2; // u    = Y2*Z1-Y1Z2
     const mnt4_Fq uu   = u.squared();                  // uu   = u^2
     const mnt4_Fq v    = X2Z1 - X1Z2; // v    = X2*Z1-X1Z2
@@ -208,7 +208,7 @@ mnt4_G1 mnt4_G1::operator+(const mnt4_G1 &other) const
 
 mnt4_G1 mnt4_G1::operator-() const
 {
-    return mnt4_G1(this->X_, -(this->Y_), this->Z_);
+    return mnt4_G1(this->X, -(this->Y), this->Z);
 }
 
 
@@ -245,12 +245,12 @@ mnt4_G1 mnt4_G1::add(const mnt4_G1 &other) const
     // NOTE: does not handle O and pts of order 2,4
     // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#addition-add-1998-cmo-2
 
-    const mnt4_Fq Y1Z2 = (this->Y_) * (other.Z_);        // Y1Z2 = Y1*Z2
-    const mnt4_Fq X1Z2 = (this->X_) * (other.Z_);        // X1Z2 = X1*Z2
-    const mnt4_Fq Z1Z2 = (this->Z_) * (other.Z_);        // Z1Z2 = Z1*Z2
-    const mnt4_Fq u    = (other.Y_) * (this->Z_) - Y1Z2; // u    = Y2*Z1-Y1Z2
+    const mnt4_Fq Y1Z2 = (this->Y) * (other.Z);        // Y1Z2 = Y1*Z2
+    const mnt4_Fq X1Z2 = (this->X) * (other.Z);        // X1Z2 = X1*Z2
+    const mnt4_Fq Z1Z2 = (this->Z) * (other.Z);        // Z1Z2 = Z1*Z2
+    const mnt4_Fq u    = (other.Y) * (this->Z) - Y1Z2; // u    = Y2*Z1-Y1Z2
     const mnt4_Fq uu   = u.squared();                    // uu   = u^2
-    const mnt4_Fq v    = (other.X_) * (this->Z_) - X1Z2; // v    = X2*Z1-X1Z2
+    const mnt4_Fq v    = (other.X) * (this->Z) - X1Z2; // v    = X2*Z1-X1Z2
     const mnt4_Fq vv   = v.squared();                    // vv   = v^2
     const mnt4_Fq vvv  = v * vv;                         // vvv  = v*vv
     const mnt4_Fq R    = vv * X1Z2;                      // R    = vv*X1Z2
@@ -285,29 +285,29 @@ mnt4_G1 mnt4_G1::mixed_add(const mnt4_G1 &other) const
     assert(other.is_special());
 #endif
 
-    const mnt4_Fq &X1Z2 = (this->X_);                    // X1Z2 = X1*Z2 (but other is special and not zero)
-    const mnt4_Fq X2Z1 = (this->Z_) * (other.X_);        // X2Z1 = X2*Z1
+    const mnt4_Fq &X1Z2 = (this->X);                    // X1Z2 = X1*Z2 (but other is special and not zero)
+    const mnt4_Fq X2Z1 = (this->Z) * (other.X);        // X2Z1 = X2*Z1
 
     // (used both in add and double checks)
 
-    const mnt4_Fq &Y1Z2 = (this->Y_);                    // Y1Z2 = Y1*Z2 (but other is special and not zero)
-    const mnt4_Fq Y2Z1 = (this->Z_) * (other.Y_);        // Y2Z1 = Y2*Z1
+    const mnt4_Fq &Y1Z2 = (this->Y);                    // Y1Z2 = Y1*Z2 (but other is special and not zero)
+    const mnt4_Fq Y2Z1 = (this->Z) * (other.Y);        // Y2Z1 = Y2*Z1
 
     if (X1Z2 == X2Z1 && Y1Z2 == Y2Z1)
     {
         return this->dbl();
     }
 
-    const mnt4_Fq u = Y2Z1 - this->Y_;              // u = Y2*Z1-Y1
+    const mnt4_Fq u = Y2Z1 - this->Y;              // u = Y2*Z1-Y1
     const mnt4_Fq uu = u.squared();                 // uu = u2
-    const mnt4_Fq v = X2Z1 - this->X_;              // v = X2*Z1-X1
+    const mnt4_Fq v = X2Z1 - this->X;              // v = X2*Z1-X1
     const mnt4_Fq vv = v.squared();                 // vv = v2
     const mnt4_Fq vvv = v*vv;                       // vvv = v*vv
-    const mnt4_Fq R = vv * this->X_;                // R = vv*X1
-    const mnt4_Fq A = uu * this->Z_ - vvv - R - R;  // A = uu*Z1-vvv-2*R
+    const mnt4_Fq R = vv * this->X;                // R = vv*X1
+    const mnt4_Fq A = uu * this->Z - vvv - R - R;  // A = uu*Z1-vvv-2*R
     const mnt4_Fq X3 = v * A;                       // X3 = v*A
-    const mnt4_Fq Y3 = u*(R-A) - vvv * this->Y_;    // Y3 = u*(R-A)-vvv*Y1
-    const mnt4_Fq Z3 = vvv * this->Z_;              // Z3 = vvv*Z1
+    const mnt4_Fq Y3 = u*(R-A) - vvv * this->Y;    // Y3 = u*(R-A)-vvv*Y1
+    const mnt4_Fq Z3 = vvv * this->Z;              // Z3 = vvv*Z1
 
     return mnt4_G1(X3, Y3, Z3);
 }
@@ -326,16 +326,16 @@ mnt4_G1 mnt4_G1::dbl() const
         // NOTE: does not handle O and pts of order 2,4
         // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#doubling-dbl-2007-bl
 
-        const mnt4_Fq XX   = (this->X_).squared();                   // XX  = X1^2
-        const mnt4_Fq ZZ   = (this->Z_).squared();                   // ZZ  = Z1^2
+        const mnt4_Fq XX   = (this->X).squared();                   // XX  = X1^2
+        const mnt4_Fq ZZ   = (this->Z).squared();                   // ZZ  = Z1^2
         const mnt4_Fq w    = mnt4_G1::coeff_a * ZZ + (XX + XX + XX); // w   = a*ZZ + 3*XX
-        const mnt4_Fq Y1Z1 = (this->Y_) * (this->Z_);
+        const mnt4_Fq Y1Z1 = (this->Y) * (this->Z);
         const mnt4_Fq s    = Y1Z1 + Y1Z1;                            // s   = 2*Y1*Z1
         const mnt4_Fq ss   = s.squared();                            // ss  = s^2
         const mnt4_Fq sss  = s * ss;                                 // sss = s*ss
-        const mnt4_Fq R    = (this->Y_) * s;                         // R   = Y1*s
+        const mnt4_Fq R    = (this->Y) * s;                         // R   = Y1*s
         const mnt4_Fq RR   = R.squared();                            // RR  = R^2
-        const mnt4_Fq B    = ((this->X_)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
+        const mnt4_Fq B    = ((this->X)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
         const mnt4_Fq h    = w.squared() - (B+B);                    // h   = w^2 - 2*B
         const mnt4_Fq X3   = h * s;                                  // X3  = h*s
         const mnt4_Fq Y3   = w * (B-h)-(RR+RR);                      // Y3  = w*(B-h) - 2*RR
@@ -363,11 +363,11 @@ bool mnt4_G1::is_well_formed() const
 
           z (y^2 - b z^2) = x ( x^2 + a z^2)
         */
-        const mnt4_Fq X2 = this->X_.squared();
-        const mnt4_Fq Y2 = this->Y_.squared();
-        const mnt4_Fq Z2 = this->Z_.squared();
+        const mnt4_Fq X2 = this->X.squared();
+        const mnt4_Fq Y2 = this->Y.squared();
+        const mnt4_Fq Z2 = this->Z.squared();
 
-        return (this->Z_ * (Y2 - mnt4_G1::coeff_b * Z2) == this->X_ * (X2 + mnt4_G1::coeff_a * Z2));
+        return (this->Z * (Y2 - mnt4_G1::coeff_b * Z2) == this->X * (X2 + mnt4_G1::coeff_a * Z2));
     }
 }
 
@@ -393,10 +393,10 @@ std::ostream& operator<<(std::ostream &out, const mnt4_G1 &g)
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
 #ifdef NO_PT_COMPRESSION
-    out << copy.X_ << OUTPUT_SEPARATOR << copy.Y_;
+    out << copy.X << OUTPUT_SEPARATOR << copy.Y;
 #else
     /* storing LSB of Y */
-    out << copy.X_ << OUTPUT_SEPARATOR << (copy.Y_.as_bigint().data[0] & 1);
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
 #endif
 
     return out;
@@ -437,9 +437,9 @@ std::istream& operator>>(std::istream &in, mnt4_G1 &g)
     // using projective coordinates
     if (!is_zero)
     {
-        g.X_ = tX;
-        g.Y_ = tY;
-        g.Z_ = mnt4_Fq::one();
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt4_Fq::one();
     }
     else
     {
@@ -489,7 +489,7 @@ void mnt4_G1::batch_to_special_all_non_zeros(std::vector<mnt4_G1> &vec)
 
     for (auto &el: vec)
     {
-        Z_vec.emplace_back(el.Z());
+        Z_vec.emplace_back(el.Z);
     }
     batch_invert<mnt4_Fq>(Z_vec);
 
@@ -497,7 +497,7 @@ void mnt4_G1::batch_to_special_all_non_zeros(std::vector<mnt4_G1> &vec)
 
     for (size_t i = 0; i < vec.size(); ++i)
     {
-        vec[i] = mnt4_G1(vec[i].X() * Z_vec[i], vec[i].Y() * Z_vec[i], one);
+        vec[i] = mnt4_G1(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
 }
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp
@@ -24,8 +24,6 @@ std::ostream& operator<<(std::ostream &, const mnt4_G1&);
 std::istream& operator>>(std::istream &, mnt4_G1&);
 
 class mnt4_G1 {
-private:
-    mnt4_Fq X_, Y_, Z_;
 public:
 #ifdef PROFILE_OP_COUNTS
     static long long add_cnt;
@@ -41,14 +39,12 @@ public:
     typedef mnt4_Fq base_field;
     typedef mnt4_Fr scalar_field;
 
+    mnt4_Fq X, Y, Z;
+
     // using projective coordinates
     mnt4_G1();
-    mnt4_G1(const mnt4_Fq& X, const mnt4_Fq& Y) : X_(X), Y_(Y), Z_(base_field::one()) {}
-    mnt4_G1(const mnt4_Fq& X, const mnt4_Fq& Y, const mnt4_Fq& Z) : X_(X), Y_(Y), Z_(Z) {}
-
-    mnt4_Fq X() const { return X_; }
-    mnt4_Fq Y() const { return Y_; }
-    mnt4_Fq Z() const { return Z_; }
+    mnt4_G1(const mnt4_Fq& X, const mnt4_Fq& Y) : X(X), Y(Y), Z(base_field::one()) {}
+    mnt4_G1(const mnt4_Fq& X, const mnt4_Fq& Y, const mnt4_Fq& Z) : X(X), Y(Y), Z(Z) {}
 
     void print() const;
     void print_coordinates() const;

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g2.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g2.cpp
@@ -40,9 +40,9 @@ mnt4_Fq2 mnt4_G2::mul_by_b(const mnt4_Fq2 &elt)
 
 mnt4_G2::mnt4_G2()
 {
-    this->X_ = G2_zero.X_;
-    this->Y_ = G2_zero.Y_;
-    this->Z_ = G2_zero.Z_;
+    this->X = G2_zero.X;
+    this->Y = G2_zero.Y;
+    this->Z = G2_zero.Z;
 }
 
 void mnt4_G2::print() const
@@ -56,10 +56,10 @@ void mnt4_G2::print() const
         mnt4_G2 copy(*this);
         copy.to_affine_coordinates();
         gmp_printf("(%Nd*z + %Nd , %Nd*z + %Nd)\n",
-                   copy.X_.c1.as_bigint().data, mnt4_Fq::num_limbs,
-                   copy.X_.c0.as_bigint().data, mnt4_Fq::num_limbs,
-                   copy.Y_.c1.as_bigint().data, mnt4_Fq::num_limbs,
-                   copy.Y_.c0.as_bigint().data, mnt4_Fq::num_limbs);
+                   copy.X.c1.as_bigint().data, mnt4_Fq::num_limbs,
+                   copy.X.c0.as_bigint().data, mnt4_Fq::num_limbs,
+                   copy.Y.c1.as_bigint().data, mnt4_Fq::num_limbs,
+                   copy.Y.c0.as_bigint().data, mnt4_Fq::num_limbs);
     }
 }
 
@@ -72,12 +72,12 @@ void mnt4_G2::print_coordinates() const
     else
     {
         gmp_printf("(%Nd*z + %Nd : %Nd*z + %Nd : %Nd*z + %Nd)\n",
-                   this->X_.c1.as_bigint().data, mnt4_Fq::num_limbs,
-                   this->X_.c0.as_bigint().data, mnt4_Fq::num_limbs,
-                   this->Y_.c1.as_bigint().data, mnt4_Fq::num_limbs,
-                   this->Y_.c0.as_bigint().data, mnt4_Fq::num_limbs,
-                   this->Z_.c1.as_bigint().data, mnt4_Fq::num_limbs,
-                   this->Z_.c0.as_bigint().data, mnt4_Fq::num_limbs);
+                   this->X.c1.as_bigint().data, mnt4_Fq::num_limbs,
+                   this->X.c0.as_bigint().data, mnt4_Fq::num_limbs,
+                   this->Y.c1.as_bigint().data, mnt4_Fq::num_limbs,
+                   this->Y.c0.as_bigint().data, mnt4_Fq::num_limbs,
+                   this->Z.c1.as_bigint().data, mnt4_Fq::num_limbs,
+                   this->Z.c0.as_bigint().data, mnt4_Fq::num_limbs);
     }
 }
 
@@ -85,16 +85,16 @@ void mnt4_G2::to_affine_coordinates()
 {
     if (this->is_zero())
     {
-        this->X_ = mnt4_Fq2::zero();
-        this->Y_ = mnt4_Fq2::one();
-        this->Z_ = mnt4_Fq2::zero();
+        this->X = mnt4_Fq2::zero();
+        this->Y = mnt4_Fq2::one();
+        this->Z = mnt4_Fq2::zero();
     }
     else
     {
-        const mnt4_Fq2 Z_inv = Z_.inverse();
-        X_ = X_ * Z_inv;
-        Y_ = Y_ * Z_inv;
-        Z_ = mnt4_Fq2::one();
+        const mnt4_Fq2 Z_inv = Z.inverse();
+        X = X * Z_inv;
+        Y = Y * Z_inv;
+        Z = mnt4_Fq2::one();
     }
 }
 
@@ -105,12 +105,12 @@ void mnt4_G2::to_special()
 
 bool mnt4_G2::is_special() const
 {
-    return (this->is_zero() || this->Z_ == mnt4_Fq2::one());
+    return (this->is_zero() || this->Z == mnt4_Fq2::one());
 }
 
 bool mnt4_G2::is_zero() const
 {
-    return (this->X_.is_zero() && this->Z_.is_zero());
+    return (this->X.is_zero() && this->Z.is_zero());
 }
 
 bool mnt4_G2::operator==(const mnt4_G2 &other) const
@@ -128,13 +128,13 @@ bool mnt4_G2::operator==(const mnt4_G2 &other) const
     /* now neither is O */
 
     // X1/Z1 = X2/Z2 <=> X1*Z2 = X2*Z1
-    if ((this->X_ * other.Z_) != (other.X_ * this->Z_))
+    if ((this->X * other.Z) != (other.X * this->Z))
     {
         return false;
     }
 
     // Y1/Z1 = Y2/Z2 <=> Y1*Z2 = Y2*Z1
-    if ((this->Y_ * other.Z_) != (other.Y_ * this->Z_))
+    if ((this->Y * other.Z) != (other.Y * this->Z))
     {
         return false;
     }
@@ -177,27 +177,27 @@ mnt4_G2 mnt4_G2::operator+(const mnt4_G2 &other) const
       }
     */
 
-    const mnt4_Fq2 X1Z2 = (this->X_) * (other.Z_);        // X1Z2 = X1*Z2
-    const mnt4_Fq2 X2Z1 = (this->Z_) * (other.X_);        // X2Z1 = X2*Z1
+    const mnt4_Fq2 X1Z2 = (this->X) * (other.Z);        // X1Z2 = X1*Z2
+    const mnt4_Fq2 X2Z1 = (this->Z) * (other.X);        // X2Z1 = X2*Z1
 
     // (used both in add and double checks)
 
-    const mnt4_Fq2 Y1Z2 = (this->Y_) * (other.Z_);        // Y1Z2 = Y1*Z2
-    const mnt4_Fq2 Y2Z1 = (this->Z_) * (other.Y_);        // Y2Z1 = Y2*Z1
+    const mnt4_Fq2 Y1Z2 = (this->Y) * (other.Z);        // Y1Z2 = Y1*Z2
+    const mnt4_Fq2 Y2Z1 = (this->Z) * (other.Y);        // Y2Z1 = Y2*Z1
 
     if (X1Z2 == X2Z1 && Y1Z2 == Y2Z1)
     {
         // perform dbl case
-        const mnt4_Fq2 XX   = (this->X_).squared();                   // XX  = X1^2
-        const mnt4_Fq2 ZZ   = (this->Z_).squared();                   // ZZ  = Z1^2
+        const mnt4_Fq2 XX   = (this->X).squared();                   // XX  = X1^2
+        const mnt4_Fq2 ZZ   = (this->Z).squared();                   // ZZ  = Z1^2
         const mnt4_Fq2 w    = mnt4_G2::mul_by_a(ZZ) + (XX + XX + XX); // w   = a*ZZ + 3*XX
-        const mnt4_Fq2 Y1Z1 = (this->Y_) * (this->Z_);
+        const mnt4_Fq2 Y1Z1 = (this->Y) * (this->Z);
         const mnt4_Fq2 s    = Y1Z1 + Y1Z1;                            // s   = 2*Y1*Z1
         const mnt4_Fq2 ss   = s.squared();                            // ss  = s^2
         const mnt4_Fq2 sss  = s * ss;                                 // sss = s*ss
-        const mnt4_Fq2 R    = (this->Y_) * s;                         // R   = Y1*s
+        const mnt4_Fq2 R    = (this->Y) * s;                         // R   = Y1*s
         const mnt4_Fq2 RR   = R.squared();                            // RR  = R^2
-        const mnt4_Fq2 B    = ((this->X_)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
+        const mnt4_Fq2 B    = ((this->X)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
         const mnt4_Fq2 h    = w.squared() - (B+B);                    // h   = w^2 - 2*B
         const mnt4_Fq2 X3   = h * s;                                  // X3  = h*s
         const mnt4_Fq2 Y3   = w * (B-h)-(RR+RR);                      // Y3  = w*(B-h) - 2*RR
@@ -207,7 +207,7 @@ mnt4_G2 mnt4_G2::operator+(const mnt4_G2 &other) const
     }
 
     // if we have arrived here we are in the add case
-    const mnt4_Fq2 Z1Z2 = (this->Z_) * (other.Z_);      // Z1Z2 = Z1*Z2
+    const mnt4_Fq2 Z1Z2 = (this->Z) * (other.Z);      // Z1Z2 = Z1*Z2
     const mnt4_Fq2 u    = Y2Z1 - Y1Z2;                  // u    = Y2*Z1-Y1Z2
     const mnt4_Fq2 uu   = u.squared();                  // uu   = u^2
     const mnt4_Fq2 v    = X2Z1 - X1Z2;                  // v    = X2*Z1-X1Z2
@@ -224,7 +224,7 @@ mnt4_G2 mnt4_G2::operator+(const mnt4_G2 &other) const
 
 mnt4_G2 mnt4_G2::operator-() const
 {
-    return mnt4_G2(this->X_, -(this->Y_), this->Z_);
+    return mnt4_G2(this->X, -(this->Y), this->Z);
 }
 
 
@@ -261,12 +261,12 @@ mnt4_G2 mnt4_G2::add(const mnt4_G2 &other) const
     // NOTE: does not handle O and pts of order 2,4
     // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#addition-add-1998-cmo-2
 
-    const mnt4_Fq2 Y1Z2 = (this->Y_) * (other.Z_);        // Y1Z2 = Y1*Z2
-    const mnt4_Fq2 X1Z2 = (this->X_) * (other.Z_);        // X1Z2 = X1*Z2
-    const mnt4_Fq2 Z1Z2 = (this->Z_) * (other.Z_);        // Z1Z2 = Z1*Z2
-    const mnt4_Fq2 u    = (other.Y_) * (this->Z_) - Y1Z2; // u    = Y2*Z1-Y1Z2
+    const mnt4_Fq2 Y1Z2 = (this->Y) * (other.Z);        // Y1Z2 = Y1*Z2
+    const mnt4_Fq2 X1Z2 = (this->X) * (other.Z);        // X1Z2 = X1*Z2
+    const mnt4_Fq2 Z1Z2 = (this->Z) * (other.Z);        // Z1Z2 = Z1*Z2
+    const mnt4_Fq2 u    = (other.Y) * (this->Z) - Y1Z2; // u    = Y2*Z1-Y1Z2
     const mnt4_Fq2 uu   = u.squared();                    // uu   = u^2
-    const mnt4_Fq2 v    = (other.X_) * (this->Z_) - X1Z2; // v    = X2*Z1-X1Z2
+    const mnt4_Fq2 v    = (other.X) * (this->Z) - X1Z2; // v    = X2*Z1-X1Z2
     const mnt4_Fq2 vv   = v.squared();                    // vv   = v^2
     const mnt4_Fq2 vvv  = v * vv;                         // vvv  = v*vv
     const mnt4_Fq2 R    = vv * X1Z2;                      // R    = vv*X1Z2
@@ -301,29 +301,29 @@ mnt4_G2 mnt4_G2::mixed_add(const mnt4_G2 &other) const
     assert(other.is_special());
 #endif
 
-    const mnt4_Fq2 &X1Z2 = (this->X_);                   // X1Z2 = X1*Z2 (but other is special and not zero)
-    const mnt4_Fq2 X2Z1 = (this->Z_) * (other.X_);       // X2Z1 = X2*Z1
+    const mnt4_Fq2 &X1Z2 = (this->X);                   // X1Z2 = X1*Z2 (but other is special and not zero)
+    const mnt4_Fq2 X2Z1 = (this->Z) * (other.X);       // X2Z1 = X2*Z1
 
     // (used both in add and double checks)
 
-    const mnt4_Fq2 &Y1Z2 = (this->Y_);                   // Y1Z2 = Y1*Z2 (but other is special and not zero)
-    const mnt4_Fq2 Y2Z1 = (this->Z_) * (other.Y_);       // Y2Z1 = Y2*Z1
+    const mnt4_Fq2 &Y1Z2 = (this->Y);                   // Y1Z2 = Y1*Z2 (but other is special and not zero)
+    const mnt4_Fq2 Y2Z1 = (this->Z) * (other.Y);       // Y2Z1 = Y2*Z1
 
     if (X1Z2 == X2Z1 && Y1Z2 == Y2Z1)
     {
         return this->dbl();
     }
 
-    const mnt4_Fq2 u = Y2Z1 - this->Y_;              // u = Y2*Z1-Y1
+    const mnt4_Fq2 u = Y2Z1 - this->Y;              // u = Y2*Z1-Y1
     const mnt4_Fq2 uu = u.squared();                 // uu = u2
-    const mnt4_Fq2 v = X2Z1 - this->X_;              // v = X2*Z1-X1
+    const mnt4_Fq2 v = X2Z1 - this->X;              // v = X2*Z1-X1
     const mnt4_Fq2 vv = v.squared();                 // vv = v2
     const mnt4_Fq2 vvv = v*vv;                       // vvv = v*vv
-    const mnt4_Fq2 R = vv * this->X_;                // R = vv*X1
-    const mnt4_Fq2 A = uu * this->Z_ - vvv - R - R;  // A = uu*Z1-vvv-2*R
+    const mnt4_Fq2 R = vv * this->X;                // R = vv*X1
+    const mnt4_Fq2 A = uu * this->Z - vvv - R - R;  // A = uu*Z1-vvv-2*R
     const mnt4_Fq2 X3 = v * A;                       // X3 = v*A
-    const mnt4_Fq2 Y3 = u*(R-A) - vvv * this->Y_;    // Y3 = u*(R-A)-vvv*Y1
-    const mnt4_Fq2 Z3 = vvv * this->Z_;              // Z3 = vvv*Z1
+    const mnt4_Fq2 Y3 = u*(R-A) - vvv * this->Y;    // Y3 = u*(R-A)-vvv*Y1
+    const mnt4_Fq2 Z3 = vvv * this->Z;              // Z3 = vvv*Z1
 
     return mnt4_G2(X3, Y3, Z3);
 }
@@ -342,16 +342,16 @@ mnt4_G2 mnt4_G2::dbl() const
         // NOTE: does not handle O and pts of order 2,4
         // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#doubling-dbl-2007-bl
 
-        const mnt4_Fq2 XX   = (this->X_).squared();                     // XX  = X1^2
-        const mnt4_Fq2 ZZ   = (this->Z_).squared();                     // ZZ  = Z1^2
+        const mnt4_Fq2 XX   = (this->X).squared();                     // XX  = X1^2
+        const mnt4_Fq2 ZZ   = (this->Z).squared();                     // ZZ  = Z1^2
         const mnt4_Fq2 w    = mnt4_G2::mul_by_a(ZZ) + (XX + XX + XX);   // w   = a*ZZ + 3*XX
-        const mnt4_Fq2 Y1Z1 = (this->Y_) * (this->Z_);
+        const mnt4_Fq2 Y1Z1 = (this->Y) * (this->Z);
         const mnt4_Fq2 s    = Y1Z1 + Y1Z1;                              // s   = 2*Y1*Z1
         const mnt4_Fq2 ss   = s.squared();                              // ss  = s^2
         const mnt4_Fq2 sss  = s * ss;                                   // sss = s*ss
-        const mnt4_Fq2 R    = (this->Y_) * s;                           // R   = Y1*s
+        const mnt4_Fq2 R    = (this->Y) * s;                           // R   = Y1*s
         const mnt4_Fq2 RR   = R.squared();                              // RR  = R^2
-        const mnt4_Fq2 B    = ((this->X_)+R).squared()-XX-RR;           // B   = (X1+R)^2 - XX - RR
+        const mnt4_Fq2 B    = ((this->X)+R).squared()-XX-RR;           // B   = (X1+R)^2 - XX - RR
         const mnt4_Fq2 h    = w.squared() - (B+B);                      // h   = w^2-2*B
         const mnt4_Fq2 X3   = h * s;                                    // X3  = h*s
         const mnt4_Fq2 Y3   = w * (B-h)-(RR+RR);                        // Y3  = w*(B-h) - 2*RR
@@ -363,9 +363,9 @@ mnt4_G2 mnt4_G2::dbl() const
 
 mnt4_G2 mnt4_G2::mul_by_q() const
 {
-    return mnt4_G2(mnt4_twist_mul_by_q_X * (this->X_).Frobenius_map(1),
-                   mnt4_twist_mul_by_q_Y * (this->Y_).Frobenius_map(1),
-                   (this->Z_).Frobenius_map(1));
+    return mnt4_G2(mnt4_twist_mul_by_q_X * (this->X).Frobenius_map(1),
+                   mnt4_twist_mul_by_q_Y * (this->Y).Frobenius_map(1),
+                   (this->Z).Frobenius_map(1));
 }
 
 bool mnt4_G2::is_well_formed() const
@@ -386,12 +386,12 @@ bool mnt4_G2::is_well_formed() const
 
           z (y^2 - b z^2) = x ( x^2 + a z^2)
         */
-        const mnt4_Fq2 X2 = this->X_.squared();
-        const mnt4_Fq2 Y2 = this->Y_.squared();
-        const mnt4_Fq2 Z2 = this->Z_.squared();
+        const mnt4_Fq2 X2 = this->X.squared();
+        const mnt4_Fq2 Y2 = this->Y.squared();
+        const mnt4_Fq2 Z2 = this->Z.squared();
         const mnt4_Fq2 aZ2 =  mnt4_twist_coeff_a * Z2;
 
-        return (this->Z_ * (Y2 - mnt4_twist_coeff_b * Z2) == this->X_ * (X2 + aZ2));
+        return (this->Z * (Y2 - mnt4_twist_coeff_b * Z2) == this->X * (X2 + aZ2));
     }
 }
 
@@ -417,10 +417,10 @@ std::ostream& operator<<(std::ostream &out, const mnt4_G2 &g)
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
 #ifdef NO_PT_COMPRESSION
-    out << copy.X_ << OUTPUT_SEPARATOR << copy.Y_;
+    out << copy.X << OUTPUT_SEPARATOR << copy.Y;
 #else
     /* storing LSB of Y */
-    out << copy.X_ << OUTPUT_SEPARATOR << (copy.Y_.c0.as_bigint().data[0] & 1);
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
 #endif
 
     return out;
@@ -461,9 +461,9 @@ std::istream& operator>>(std::istream &in, mnt4_G2 &g)
     // using projective coordinates
     if (!is_zero)
     {
-        g.X_ = tX;
-        g.Y_ = tY;
-        g.Z_ = mnt4_Fq2::one();
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt4_Fq2::one();
     }
     else
     {
@@ -480,7 +480,7 @@ void mnt4_G2::batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec)
 
     for (auto &el: vec)
     {
-        Z_vec.emplace_back(el.Z());
+        Z_vec.emplace_back(el.Z);
     }
     batch_invert<mnt4_Fq2>(Z_vec);
 
@@ -488,7 +488,7 @@ void mnt4_G2::batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec)
 
     for (size_t i = 0; i < vec.size(); ++i)
     {
-        vec[i] = mnt4_G2(vec[i].X() * Z_vec[i], vec[i].Y() * Z_vec[i], one);
+        vec[i] = mnt4_G2(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
 }
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp
@@ -24,8 +24,6 @@ std::ostream& operator<<(std::ostream &, const mnt4_G2&);
 std::istream& operator>>(std::istream &, mnt4_G2&);
 
 class mnt4_G2 {
-private:
-    mnt4_Fq2 X_, Y_, Z_;
 public:
 #ifdef PROFILE_OP_COUNTS
     static long long add_cnt;
@@ -43,13 +41,11 @@ public:
     typedef mnt4_Fq2 twist_field;
     typedef mnt4_Fr scalar_field;
 
+    mnt4_Fq2 X, Y, Z;
+
     // using projective coordinates
     mnt4_G2();
-    mnt4_G2(const mnt4_Fq2& X, const mnt4_Fq2& Y, const mnt4_Fq2& Z) : X_(X), Y_(Y), Z_(Z) {};
-
-    mnt4_Fq2 X() const { return X_; }
-    mnt4_Fq2 Y() const { return Y_; }
-    mnt4_Fq2 Z() const { return Z_; }
+    mnt4_G2(const mnt4_Fq2& X, const mnt4_Fq2& Y, const mnt4_Fq2& Z) : X(X), Y(Y), Z(Z) {};
 
     static mnt4_Fq2 mul_by_a(const mnt4_Fq2 &elt);
     static mnt4_Fq2 mul_by_b(const mnt4_Fq2 &elt);

--- a/libff/algebra/curves/mnt/mnt4/mnt4_pairing.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_pairing.cpp
@@ -232,9 +232,9 @@ mnt4_affine_ate_G1_precomputation mnt4_affine_ate_precompute_G1(const mnt4_G1& P
     Pcopy.to_affine_coordinates();
 
     mnt4_affine_ate_G1_precomputation result;
-    result.PX = Pcopy.X();
-    result.PY = Pcopy.Y();
-    result.PY_twist_squared = Pcopy.Y() * mnt4_twist.squared();
+    result.PX = Pcopy.X;
+    result.PY = Pcopy.Y;
+    result.PY_twist_squared = Pcopy.Y * mnt4_twist.squared();
 
     leave_block("Call to mnt4_affine_ate_precompute_G1");
     return result;
@@ -248,11 +248,11 @@ mnt4_affine_ate_G2_precomputation mnt4_affine_ate_precompute_G2(const mnt4_G2& Q
     Qcopy.to_affine_coordinates();
 
     mnt4_affine_ate_G2_precomputation result;
-    result.QX = Qcopy.X();
-    result.QY = Qcopy.Y();
+    result.QX = Qcopy.X;
+    result.QY = Qcopy.Y;
 
-    mnt4_Fq2 RX = Qcopy.X();
-    mnt4_Fq2 RY = Qcopy.Y();
+    mnt4_Fq2 RX = Qcopy.X;
+    mnt4_Fq2 RY = Qcopy.Y;
 
     const bigint<mnt4_Fr::num_limbs> &loop_count = mnt4_ate_loop_count;
     bool found_nonzero = false;
@@ -471,10 +471,10 @@ mnt4_ate_G1_precomp mnt4_ate_precompute_G1(const mnt4_G1& P)
     Pcopy.to_affine_coordinates();
 
     mnt4_ate_G1_precomp result;
-    result.PX = Pcopy.X();
-    result.PY = Pcopy.Y();
-    result.PX_twist = Pcopy.X() * mnt4_twist;
-    result.PY_twist = Pcopy.Y() * mnt4_twist;
+    result.PX = Pcopy.X;
+    result.PY = Pcopy.Y;
+    result.PX_twist = Pcopy.X * mnt4_twist;
+    result.PY_twist = Pcopy.Y * mnt4_twist;
 
     leave_block("Call to mnt4_ate_precompute_G1");
     return result;
@@ -488,15 +488,15 @@ mnt4_ate_G2_precomp mnt4_ate_precompute_G2(const mnt4_G2& Q)
     Qcopy.to_affine_coordinates();
 
     mnt4_ate_G2_precomp result;
-    result.QX = Qcopy.X();
-    result.QY = Qcopy.Y();
-    result.QY2 = Qcopy.Y().squared();
-    result.QX_over_twist = Qcopy.X() * mnt4_twist.inverse();
-    result.QY_over_twist = Qcopy.Y() * mnt4_twist.inverse();
+    result.QX = Qcopy.X;
+    result.QY = Qcopy.Y;
+    result.QY2 = Qcopy.Y.squared();
+    result.QX_over_twist = Qcopy.X * mnt4_twist.inverse();
+    result.QY_over_twist = Qcopy.Y * mnt4_twist.inverse();
 
     extended_mnt4_G2_projective R;
-    R.X = Qcopy.X();
-    R.Y = Qcopy.Y();
+    R.X = Qcopy.X;
+    R.Y = Qcopy.Y;
     R.Z = mnt4_Fq2::one();
     R.T = mnt4_Fq2::one();
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g1.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g1.cpp
@@ -29,9 +29,9 @@ mnt6_Fq mnt6_G1::coeff_b;
 
 mnt6_G1::mnt6_G1()
 {
-    this->X_ = G1_zero.X_;
-    this->Y_ = G1_zero.Y_;
-    this->Z_ = G1_zero.Z_;
+    this->X = G1_zero.X;
+    this->Y = G1_zero.Y;
+    this->Z = G1_zero.Z;
 }
 
 void mnt6_G1::print() const
@@ -45,8 +45,8 @@ void mnt6_G1::print() const
         mnt6_G1 copy(*this);
         copy.to_affine_coordinates();
         gmp_printf("(%Nd , %Nd)\n",
-                   copy.X_.as_bigint().data, mnt6_Fq::num_limbs,
-                   copy.Y_.as_bigint().data, mnt6_Fq::num_limbs);
+                   copy.X.as_bigint().data, mnt6_Fq::num_limbs,
+                   copy.Y.as_bigint().data, mnt6_Fq::num_limbs);
     }
 }
 
@@ -59,9 +59,9 @@ void mnt6_G1::print_coordinates() const
     else
     {
         gmp_printf("(%Nd : %Nd : %Nd)\n",
-                   this->X_.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->Y_.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->Z_.as_bigint().data, mnt6_Fq::num_limbs);
+                   this->X.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->Y.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->Z.as_bigint().data, mnt6_Fq::num_limbs);
     }
 }
 
@@ -69,16 +69,16 @@ void mnt6_G1::to_affine_coordinates()
 {
     if (this->is_zero())
     {
-        this->X_ = mnt6_Fq::zero();
-        this->Y_ = mnt6_Fq::one();
-        this->Z_ = mnt6_Fq::zero();
+        this->X = mnt6_Fq::zero();
+        this->Y = mnt6_Fq::one();
+        this->Z = mnt6_Fq::zero();
     }
     else
     {
-        const mnt6_Fq Z_inv = Z_.inverse();
-        this->X_ = this->X_ * Z_inv;
-        this->Y_ = this->Y_ * Z_inv;
-        this->Z_ = mnt6_Fq::one();
+        const mnt6_Fq Z_inv = Z.inverse();
+        this->X = this->X * Z_inv;
+        this->Y = this->Y * Z_inv;
+        this->Z = mnt6_Fq::one();
     }
 }
 
@@ -89,12 +89,12 @@ void mnt6_G1::to_special()
 
 bool mnt6_G1::is_special() const
 {
-    return (this->is_zero() || this->Z_ == mnt6_Fq::one());
+    return (this->is_zero() || this->Z == mnt6_Fq::one());
 }
 
 bool mnt6_G1::is_zero() const
 {
-    return (this->X_.is_zero() && this->Z_.is_zero());
+    return (this->X.is_zero() && this->Z.is_zero());
 }
 
 bool mnt6_G1::operator==(const mnt6_G1 &other) const
@@ -112,13 +112,13 @@ bool mnt6_G1::operator==(const mnt6_G1 &other) const
     /* now neither is O */
 
     // X1/Z1 = X2/Z2 <=> X1*Z2 = X2*Z1
-    if ((this->X_ * other.Z_) != (other.X_ * this->Z_))
+    if ((this->X * other.Z) != (other.X * this->Z))
     {
         return false;
     }
 
     // Y1/Z1 = Y2/Z2 <=> Y1*Z2 = Y2*Z1
-    if ((this->Y_ * other.Z_) != (other.Y_ * this->Z_))
+    if ((this->Y * other.Z) != (other.Y * this->Z))
     {
         return false;
     }
@@ -161,27 +161,27 @@ mnt6_G1 mnt6_G1::operator+(const mnt6_G1 &other) const
       }
     */
 
-    const mnt6_Fq X1Z2 = (this->X_) * (other.Z_);        // X1Z2 = X1*Z2
-    const mnt6_Fq X2Z1 = (this->Z_) * (other.X_);        // X2Z1 = X2*Z1
+    const mnt6_Fq X1Z2 = (this->X) * (other.Z);        // X1Z2 = X1*Z2
+    const mnt6_Fq X2Z1 = (this->Z) * (other.X);        // X2Z1 = X2*Z1
 
     // (used both in add and double checks)
 
-    const mnt6_Fq Y1Z2 = (this->Y_) * (other.Z_);        // Y1Z2 = Y1*Z2
-    const mnt6_Fq Y2Z1 = (this->Z_) * (other.Y_);        // Y2Z1 = Y2*Z1
+    const mnt6_Fq Y1Z2 = (this->Y) * (other.Z);        // Y1Z2 = Y1*Z2
+    const mnt6_Fq Y2Z1 = (this->Z) * (other.Y);        // Y2Z1 = Y2*Z1
 
     if (X1Z2 == X2Z1 && Y1Z2 == Y2Z1)
     {
         // perform dbl case
-        const mnt6_Fq XX   = (this->X_).squared();                   // XX  = X1^2
-        const mnt6_Fq ZZ   = (this->Z_).squared();                   // ZZ  = Z1^2
+        const mnt6_Fq XX   = (this->X).squared();                   // XX  = X1^2
+        const mnt6_Fq ZZ   = (this->Z).squared();                   // ZZ  = Z1^2
         const mnt6_Fq w    = mnt6_G1::coeff_a * ZZ + (XX + XX + XX); // w   = a*ZZ + 3*XX
-        const mnt6_Fq Y1Z1 = (this->Y_) * (this->Z_);
+        const mnt6_Fq Y1Z1 = (this->Y) * (this->Z);
         const mnt6_Fq s    = Y1Z1 + Y1Z1;                            // s   = 2*Y1*Z1
         const mnt6_Fq ss   = s.squared();                            // ss  = s^2
         const mnt6_Fq sss  = s * ss;                                 // sss = s*ss
-        const mnt6_Fq R    = (this->Y_) * s;                         // R   = Y1*s
+        const mnt6_Fq R    = (this->Y) * s;                         // R   = Y1*s
         const mnt6_Fq RR   = R.squared();                            // RR  = R^2
-        const mnt6_Fq B    = ((this->X_)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
+        const mnt6_Fq B    = ((this->X)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
         const mnt6_Fq h    = w.squared() - (B+B);                    // h   = w^2 - 2*B
         const mnt6_Fq X3   = h * s;                                  // X3  = h*s
         const mnt6_Fq Y3   = w * (B-h)-(RR+RR);                      // Y3  = w*(B-h) - 2*RR
@@ -191,7 +191,7 @@ mnt6_G1 mnt6_G1::operator+(const mnt6_G1 &other) const
     }
 
     // if we have arrived here we are in the add case
-    const mnt6_Fq Z1Z2 = (this->Z_) * (other.Z_);      // Z1Z2 = Z1*Z2
+    const mnt6_Fq Z1Z2 = (this->Z) * (other.Z);      // Z1Z2 = Z1*Z2
     const mnt6_Fq u    = Y2Z1 - Y1Z2;                  // u    = Y2*Z1-Y1Z2
     const mnt6_Fq uu   = u.squared();                  // uu   = u^2
     const mnt6_Fq v    = X2Z1 - X1Z2;                  // v    = X2*Z1-X1Z2
@@ -208,7 +208,7 @@ mnt6_G1 mnt6_G1::operator+(const mnt6_G1 &other) const
 
 mnt6_G1 mnt6_G1::operator-() const
 {
-    return mnt6_G1(this->X_, -(this->Y_), this->Z_);
+    return mnt6_G1(this->X, -(this->Y), this->Z);
 }
 
 
@@ -245,12 +245,12 @@ mnt6_G1 mnt6_G1::add(const mnt6_G1 &other) const
     // NOTE: does not handle O and pts of order 2,4
     // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#addition-add-1998-cmo-2
 
-    const mnt6_Fq Y1Z2 = (this->Y_) * (other.Z_);        // Y1Z2 = Y1*Z2
-    const mnt6_Fq X1Z2 = (this->X_) * (other.Z_);        // X1Z2 = X1*Z2
-    const mnt6_Fq Z1Z2 = (this->Z_) * (other.Z_);        // Z1Z2 = Z1*Z2
-    const mnt6_Fq u    = (other.Y_) * (this->Z_) - Y1Z2; // u    = Y2*Z1-Y1Z2
+    const mnt6_Fq Y1Z2 = (this->Y) * (other.Z);        // Y1Z2 = Y1*Z2
+    const mnt6_Fq X1Z2 = (this->X) * (other.Z);        // X1Z2 = X1*Z2
+    const mnt6_Fq Z1Z2 = (this->Z) * (other.Z);        // Z1Z2 = Z1*Z2
+    const mnt6_Fq u    = (other.Y) * (this->Z) - Y1Z2; // u    = Y2*Z1-Y1Z2
     const mnt6_Fq uu   = u.squared();                    // uu   = u^2
-    const mnt6_Fq v    = (other.X_) * (this->Z_) - X1Z2; // v    = X2*Z1-X1Z2
+    const mnt6_Fq v    = (other.X) * (this->Z) - X1Z2; // v    = X2*Z1-X1Z2
     const mnt6_Fq vv   = v.squared();                    // vv   = v^2
     const mnt6_Fq vvv  = v * vv;                         // vvv  = v*vv
     const mnt6_Fq R    = vv * X1Z2;                      // R    = vv*X1Z2
@@ -285,29 +285,29 @@ mnt6_G1 mnt6_G1::mixed_add(const mnt6_G1 &other) const
     assert(other.is_special());
 #endif
 
-    const mnt6_Fq &X1Z2 = (this->X_);                    // X1Z2 = X1*Z2 (but other is special and not zero)
-    const mnt6_Fq X2Z1 = (this->Z_) * (other.X_);        // X2Z1 = X2*Z1
+    const mnt6_Fq &X1Z2 = (this->X);                    // X1Z2 = X1*Z2 (but other is special and not zero)
+    const mnt6_Fq X2Z1 = (this->Z) * (other.X);        // X2Z1 = X2*Z1
 
     // (used both in add and double checks)
 
-    const mnt6_Fq &Y1Z2 = (this->Y_);                    // Y1Z2 = Y1*Z2 (but other is special and not zero)
-    const mnt6_Fq Y2Z1 = (this->Z_) * (other.Y_);        // Y2Z1 = Y2*Z1
+    const mnt6_Fq &Y1Z2 = (this->Y);                    // Y1Z2 = Y1*Z2 (but other is special and not zero)
+    const mnt6_Fq Y2Z1 = (this->Z) * (other.Y);        // Y2Z1 = Y2*Z1
 
     if (X1Z2 == X2Z1 && Y1Z2 == Y2Z1)
     {
         return this->dbl();
     }
 
-    mnt6_Fq u = Y2Z1 - this->Y_;             // u = Y2*Z1-Y1
+    mnt6_Fq u = Y2Z1 - this->Y;             // u = Y2*Z1-Y1
     mnt6_Fq uu = u.squared();                // uu = u2
-    mnt6_Fq v = X2Z1 - this->X_;             // v = X2*Z1-X1
+    mnt6_Fq v = X2Z1 - this->X;             // v = X2*Z1-X1
     mnt6_Fq vv = v.squared();                // vv = v2
     mnt6_Fq vvv = v*vv;                      // vvv = v*vv
-    mnt6_Fq R = vv * this->X_;               // R = vv*X1
-    mnt6_Fq A = uu * this->Z_ - vvv - R - R; // A = uu*Z1-vvv-2*R
+    mnt6_Fq R = vv * this->X;               // R = vv*X1
+    mnt6_Fq A = uu * this->Z - vvv - R - R; // A = uu*Z1-vvv-2*R
     mnt6_Fq X3 = v * A;                      // X3 = v*A
-    mnt6_Fq Y3 = u*(R-A) - vvv * this->Y_;   // Y3 = u*(R-A)-vvv*Y1
-    mnt6_Fq Z3 = vvv * this->Z_;             // Z3 = vvv*Z1
+    mnt6_Fq Y3 = u*(R-A) - vvv * this->Y;   // Y3 = u*(R-A)-vvv*Y1
+    mnt6_Fq Z3 = vvv * this->Z;             // Z3 = vvv*Z1
 
     return mnt6_G1(X3, Y3, Z3);
 }
@@ -326,16 +326,16 @@ mnt6_G1 mnt6_G1::dbl() const
         // NOTE: does not handle O and pts of order 2,4
         // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#doubling-dbl-2007-bl
 
-        const mnt6_Fq XX   = (this->X_).squared();                   // XX  = X1^2
-        const mnt6_Fq ZZ   = (this->Z_).squared();                   // ZZ  = Z1^2
+        const mnt6_Fq XX   = (this->X).squared();                   // XX  = X1^2
+        const mnt6_Fq ZZ   = (this->Z).squared();                   // ZZ  = Z1^2
         const mnt6_Fq w    = mnt6_G1::coeff_a * ZZ + (XX + XX + XX); // w   = a*ZZ + 3*XX
-        const mnt6_Fq Y1Z1 = (this->Y_) * (this->Z_);
+        const mnt6_Fq Y1Z1 = (this->Y) * (this->Z);
         const mnt6_Fq s    = Y1Z1 + Y1Z1;                            // s   = 2*Y1*Z1
         const mnt6_Fq ss   = s.squared();                            // ss  = s^2
         const mnt6_Fq sss  = s * ss;                                 // sss = s*ss
-        const mnt6_Fq R    = (this->Y_) * s;                         // R   = Y1*s
+        const mnt6_Fq R    = (this->Y) * s;                         // R   = Y1*s
         const mnt6_Fq RR   = R.squared();                            // RR  = R^2
-        const mnt6_Fq B    = ((this->X_)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
+        const mnt6_Fq B    = ((this->X)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
         const mnt6_Fq h    = w.squared() - (B+B);                    // h   = w^2 - 2*B
         const mnt6_Fq X3   = h * s;                                  // X3  = h*s
         const mnt6_Fq Y3   = w * (B-h)-(RR+RR);                      // Y3  = w*(B-h) - 2*RR
@@ -363,11 +363,11 @@ bool mnt6_G1::is_well_formed() const
 
           z (y^2 - b z^2) = x ( x^2 + a z^2)
         */
-        const mnt6_Fq X2 = this->X_.squared();
-        const mnt6_Fq Y2 = this->Y_.squared();
-        const mnt6_Fq Z2 = this->Z_.squared();
+        const mnt6_Fq X2 = this->X.squared();
+        const mnt6_Fq Y2 = this->Y.squared();
+        const mnt6_Fq Z2 = this->Z.squared();
 
-        return (this->Z_ * (Y2 - mnt6_G1::coeff_b * Z2) == this->X_ * (X2 + mnt6_G1::coeff_a * Z2));
+        return (this->Z * (Y2 - mnt6_G1::coeff_b * Z2) == this->X * (X2 + mnt6_G1::coeff_a * Z2));
     }
 }
 
@@ -393,10 +393,10 @@ std::ostream& operator<<(std::ostream &out, const mnt6_G1 &g)
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
 #ifdef NO_PT_COMPRESSION
-    out << copy.X_ << OUTPUT_SEPARATOR << copy.Y_;
+    out << copy.X << OUTPUT_SEPARATOR << copy.Y;
 #else
     /* storing LSB of Y */
-    out << copy.X_ << OUTPUT_SEPARATOR << (copy.Y_.as_bigint().data[0] & 1);
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
 #endif
 
     return out;
@@ -437,9 +437,9 @@ std::istream& operator>>(std::istream &in, mnt6_G1 &g)
     // using projective coordinates
     if (!is_zero)
     {
-        g.X_ = tX;
-        g.Y_ = tY;
-        g.Z_ = mnt6_Fq::one();
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt6_Fq::one();
     }
     else
     {
@@ -488,7 +488,7 @@ void mnt6_G1::batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec)
 
     for (auto &el: vec)
     {
-        Z_vec.emplace_back(el.Z());
+        Z_vec.emplace_back(el.Z);
     }
     batch_invert<mnt6_Fq>(Z_vec);
 
@@ -496,7 +496,7 @@ void mnt6_G1::batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec)
 
     for (size_t i = 0; i < vec.size(); ++i)
     {
-        vec[i] = mnt6_G1(vec[i].X() * Z_vec[i], vec[i].Y() * Z_vec[i], one);
+        vec[i] = mnt6_G1(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
 }
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp
@@ -24,8 +24,6 @@ std::ostream& operator<<(std::ostream &, const mnt6_G1&);
 std::istream& operator>>(std::istream &, mnt6_G1&);
 
 class mnt6_G1 {
-private:
-    mnt6_Fq X_, Y_, Z_;
 public:
 #ifdef PROFILE_OP_COUNTS
     static long long add_cnt;
@@ -41,14 +39,12 @@ public:
     typedef mnt6_Fq base_field;
     typedef mnt6_Fr scalar_field;
 
+    mnt6_Fq X, Y, Z;
+
     // using projective coordinates
     mnt6_G1();
-    mnt6_G1(const mnt6_Fq& X, const mnt6_Fq& Y) : X_(X), Y_(Y), Z_(base_field::one()) {}
-    mnt6_G1(const mnt6_Fq& X, const mnt6_Fq& Y, const mnt6_Fq& Z) : X_(X), Y_(Y), Z_(Z) {}
-
-    mnt6_Fq X() const { return X_; }
-    mnt6_Fq Y() const { return Y_; }
-    mnt6_Fq Z() const { return Z_; }
+    mnt6_G1(const mnt6_Fq& X, const mnt6_Fq& Y) : X(X), Y(Y), Z(base_field::one()) {}
+    mnt6_G1(const mnt6_Fq& X, const mnt6_Fq& Y, const mnt6_Fq& Z) : X(X), Y(Y), Z(Z) {}
 
     void print() const;
     void print_coordinates() const;

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g2.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g2.cpp
@@ -30,9 +30,9 @@ mnt6_G2 mnt6_G2::G2_one;
 
 mnt6_G2::mnt6_G2()
 {
-    this->X_ = G2_zero.X_;
-    this->Y_ = G2_zero.Y_;
-    this->Z_ = G2_zero.Z_;
+    this->X = G2_zero.X;
+    this->Y = G2_zero.Y;
+    this->Z = G2_zero.Z;
 }
 
 mnt6_Fq3 mnt6_G2::mul_by_a(const mnt6_Fq3 &elt)
@@ -56,12 +56,12 @@ void mnt6_G2::print() const
         mnt6_G2 copy(*this);
         copy.to_affine_coordinates();
         gmp_printf("(%Nd*z^2 + %Nd*z + %Nd , %Nd*z^2 + %Nd*z + %Nd)\n",
-                   copy.X_.c2.as_bigint().data, mnt6_Fq::num_limbs,
-                   copy.X_.c1.as_bigint().data, mnt6_Fq::num_limbs,
-                   copy.X_.c0.as_bigint().data, mnt6_Fq::num_limbs,
-                   copy.Y_.c2.as_bigint().data, mnt6_Fq::num_limbs,
-                   copy.Y_.c1.as_bigint().data, mnt6_Fq::num_limbs,
-                   copy.Y_.c0.as_bigint().data, mnt6_Fq::num_limbs);
+                   copy.X.c2.as_bigint().data, mnt6_Fq::num_limbs,
+                   copy.X.c1.as_bigint().data, mnt6_Fq::num_limbs,
+                   copy.X.c0.as_bigint().data, mnt6_Fq::num_limbs,
+                   copy.Y.c2.as_bigint().data, mnt6_Fq::num_limbs,
+                   copy.Y.c1.as_bigint().data, mnt6_Fq::num_limbs,
+                   copy.Y.c0.as_bigint().data, mnt6_Fq::num_limbs);
     }
 }
 
@@ -74,15 +74,15 @@ void mnt6_G2::print_coordinates() const
     else
     {
         gmp_printf("(%Nd*z^2 + %Nd*z + %Nd : %Nd*z^2 + %Nd*z + %Nd : %Nd*z^2 + %Nd*z + %Nd)\n",
-                   this->X_.c2.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->X_.c1.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->X_.c0.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->Y_.c2.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->Y_.c1.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->Y_.c0.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->Z_.c2.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->Z_.c1.as_bigint().data, mnt6_Fq::num_limbs,
-                   this->Z_.c0.as_bigint().data, mnt6_Fq::num_limbs);
+                   this->X.c2.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->X.c1.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->X.c0.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->Y.c2.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->Y.c1.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->Y.c0.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->Z.c2.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->Z.c1.as_bigint().data, mnt6_Fq::num_limbs,
+                   this->Z.c0.as_bigint().data, mnt6_Fq::num_limbs);
     }
 }
 
@@ -90,16 +90,16 @@ void mnt6_G2::to_affine_coordinates()
 {
     if (this->is_zero())
     {
-        this->X_ = mnt6_Fq3::zero();
-        this->Y_ = mnt6_Fq3::one();
-        this->Z_ = mnt6_Fq3::zero();
+        this->X = mnt6_Fq3::zero();
+        this->Y = mnt6_Fq3::one();
+        this->Z = mnt6_Fq3::zero();
     }
     else
     {
-        const mnt6_Fq3 Z_inv = Z_.inverse();
-        this->X_ = this->X_ * Z_inv;
-        this->Y_ = this->Y_ * Z_inv;
-        this->Z_ = mnt6_Fq3::one();
+        const mnt6_Fq3 Z_inv = Z.inverse();
+        this->X = this->X * Z_inv;
+        this->Y = this->Y * Z_inv;
+        this->Z = mnt6_Fq3::one();
     }
 }
 
@@ -110,13 +110,13 @@ void mnt6_G2::to_special()
 
 bool mnt6_G2::is_special() const
 {
-    return (this->is_zero() || this->Z_ == mnt6_Fq3::one());
+    return (this->is_zero() || this->Z == mnt6_Fq3::one());
 }
 
 bool mnt6_G2::is_zero() const
 {
     // TODO: use zero for here
-    return (this->X_.is_zero() && this->Z_.is_zero());
+    return (this->X.is_zero() && this->Z.is_zero());
 }
 
 bool mnt6_G2::operator==(const mnt6_G2 &other) const
@@ -134,13 +134,13 @@ bool mnt6_G2::operator==(const mnt6_G2 &other) const
     /* now neither is O */
 
     // X1/Z1 = X2/Z2 <=> X1*Z2 = X2*Z1
-    if ((this->X_ * other.Z_) != (other.X_ * this->Z_))
+    if ((this->X * other.Z) != (other.X * this->Z))
     {
         return false;
     }
 
     // Y1/Z1 = Y2/Z2 <=> Y1*Z2 = Y2*Z1
-    if ((this->Y_ * other.Z_) != (other.Y_ * this->Z_))
+    if ((this->Y * other.Z) != (other.Y * this->Z))
     {
         return false;
     }
@@ -183,27 +183,27 @@ mnt6_G2 mnt6_G2::operator+(const mnt6_G2 &other) const
       }
     */
 
-    const mnt6_Fq3 X1Z2 = (this->X_) * (other.Z_);        // X1Z2 = X1*Z2
-    const mnt6_Fq3 X2Z1 = (this->Z_) * (other.X_);        // X2Z1 = X2*Z1
+    const mnt6_Fq3 X1Z2 = (this->X) * (other.Z);        // X1Z2 = X1*Z2
+    const mnt6_Fq3 X2Z1 = (this->Z) * (other.X);        // X2Z1 = X2*Z1
 
     // (used both in add and double checks)
 
-    const mnt6_Fq3 Y1Z2 = (this->Y_) * (other.Z_);        // Y1Z2 = Y1*Z2
-    const mnt6_Fq3 Y2Z1 = (this->Z_) * (other.Y_);        // Y2Z1 = Y2*Z1
+    const mnt6_Fq3 Y1Z2 = (this->Y) * (other.Z);        // Y1Z2 = Y1*Z2
+    const mnt6_Fq3 Y2Z1 = (this->Z) * (other.Y);        // Y2Z1 = Y2*Z1
 
     if (X1Z2 == X2Z1 && Y1Z2 == Y2Z1)
     {
         // perform dbl case
-        const mnt6_Fq3 XX   = (this->X_).squared();                   // XX  = X1^2
-        const mnt6_Fq3 ZZ   = (this->Z_).squared();                   // ZZ  = Z1^2
+        const mnt6_Fq3 XX   = (this->X).squared();                   // XX  = X1^2
+        const mnt6_Fq3 ZZ   = (this->Z).squared();                   // ZZ  = Z1^2
         const mnt6_Fq3 w    = mnt6_G2::mul_by_a(ZZ) + (XX + XX + XX); // w   = a*ZZ + 3*XX
-        const mnt6_Fq3 Y1Z1 = (this->Y_) * (this->Z_);
+        const mnt6_Fq3 Y1Z1 = (this->Y) * (this->Z);
         const mnt6_Fq3 s    = Y1Z1 + Y1Z1;                             // s   = 2*Y1*Z1
         const mnt6_Fq3 ss   = s.squared();                             // ss  = s^2
         const mnt6_Fq3 sss  = s * ss;                                  // sss = s*ss
-        const mnt6_Fq3 R    = (this->Y_) * s;                          // R   = Y1*s
+        const mnt6_Fq3 R    = (this->Y) * s;                          // R   = Y1*s
         const mnt6_Fq3 RR   = R.squared();                             // RR  = R^2
-        const mnt6_Fq3 B    = ((this->X_)+R).squared()-XX-RR;          // B   = (X1+R)^2 - XX - RR
+        const mnt6_Fq3 B    = ((this->X)+R).squared()-XX-RR;          // B   = (X1+R)^2 - XX - RR
         const mnt6_Fq3 h    = w.squared() - (B+B);                     // h   = w^2 - 2*B
         const mnt6_Fq3 X3   = h * s;                                   // X3  = h*s
         const mnt6_Fq3 Y3   = w * (B-h)-(RR+RR);                       // Y3  = w*(B-h) - 2*RR
@@ -213,7 +213,7 @@ mnt6_G2 mnt6_G2::operator+(const mnt6_G2 &other) const
     }
 
     // if we have arrived here we are in the add case
-    const mnt6_Fq3 Z1Z2 = (this->Z_) * (other.Z_);   // Z1Z2 = Z1*Z2
+    const mnt6_Fq3 Z1Z2 = (this->Z) * (other.Z);   // Z1Z2 = Z1*Z2
     const mnt6_Fq3 u    = Y2Z1 - Y1Z2;               // u    = Y2*Z1-Y1Z2
     const mnt6_Fq3 uu   = u.squared();               // uu   = u^2
     const mnt6_Fq3 v    = X2Z1 - X1Z2;               // v    = X2*Z1-X1Z2
@@ -230,7 +230,7 @@ mnt6_G2 mnt6_G2::operator+(const mnt6_G2 &other) const
 
 mnt6_G2 mnt6_G2::operator-() const
 {
-    return mnt6_G2(this->X_, -(this->Y_), this->Z_);
+    return mnt6_G2(this->X, -(this->Y), this->Z);
 }
 
 
@@ -267,12 +267,12 @@ mnt6_G2 mnt6_G2::add(const mnt6_G2 &other) const
     // NOTE: does not handle O and pts of order 2,4
     // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#addition-add-1998-cmo-2
 
-    const mnt6_Fq3 Y1Z2 = (this->Y_) * (other.Z_);        // Y1Z2 = Y1*Z2
-    const mnt6_Fq3 X1Z2 = (this->X_) * (other.Z_);        // X1Z2 = X1*Z2
-    const mnt6_Fq3 Z1Z2 = (this->Z_) * (other.Z_);        // Z1Z2 = Z1*Z2
-    const mnt6_Fq3 u    = (other.Y_) * (this->Z_) - Y1Z2; // u    = Y2*Z1-Y1Z2
+    const mnt6_Fq3 Y1Z2 = (this->Y) * (other.Z);        // Y1Z2 = Y1*Z2
+    const mnt6_Fq3 X1Z2 = (this->X) * (other.Z);        // X1Z2 = X1*Z2
+    const mnt6_Fq3 Z1Z2 = (this->Z) * (other.Z);        // Z1Z2 = Z1*Z2
+    const mnt6_Fq3 u    = (other.Y) * (this->Z) - Y1Z2; // u    = Y2*Z1-Y1Z2
     const mnt6_Fq3 uu   = u.squared();                    // uu   = u^2
-    const mnt6_Fq3 v    = (other.X_) * (this->Z_) - X1Z2; // v    = X2*Z1-X1Z2
+    const mnt6_Fq3 v    = (other.X) * (this->Z) - X1Z2; // v    = X2*Z1-X1Z2
     const mnt6_Fq3 vv   = v.squared();                    // vv   = v^2
     const mnt6_Fq3 vvv  = v * vv;                         // vvv  = v*vv
     const mnt6_Fq3 R    = vv * X1Z2;                      // R    = vv*X1Z2
@@ -307,29 +307,29 @@ mnt6_G2 mnt6_G2::mixed_add(const mnt6_G2 &other) const
     assert(other.is_special());
 #endif
 
-    const mnt6_Fq3 &X1Z2 = (this->X_);                   // X1Z2 = X1*Z2 (but other is special and not zero)
-    const mnt6_Fq3 X2Z1 = (this->Z_) * (other.X_);       // X2Z1 = X2*Z1
+    const mnt6_Fq3 &X1Z2 = (this->X);                   // X1Z2 = X1*Z2 (but other is special and not zero)
+    const mnt6_Fq3 X2Z1 = (this->Z) * (other.X);       // X2Z1 = X2*Z1
 
     // (used both in add and double checks)
 
-    const mnt6_Fq3 &Y1Z2 = (this->Y_);                   // Y1Z2 = Y1*Z2 (but other is special and not zero)
-    const mnt6_Fq3 Y2Z1 = (this->Z_) * (other.Y_);       // Y2Z1 = Y2*Z1
+    const mnt6_Fq3 &Y1Z2 = (this->Y);                   // Y1Z2 = Y1*Z2 (but other is special and not zero)
+    const mnt6_Fq3 Y2Z1 = (this->Z) * (other.Y);       // Y2Z1 = Y2*Z1
 
     if (X1Z2 == X2Z1 && Y1Z2 == Y2Z1)
     {
         return this->dbl();
     }
 
-    const mnt6_Fq3 u = Y2Z1 - this->Y_;             // u = Y2*Z1-Y1
+    const mnt6_Fq3 u = Y2Z1 - this->Y;             // u = Y2*Z1-Y1
     const mnt6_Fq3 uu = u.squared();                // uu = u2
-    const mnt6_Fq3 v = X2Z1 - this->X_;             // v = X2*Z1-X1
+    const mnt6_Fq3 v = X2Z1 - this->X;             // v = X2*Z1-X1
     const mnt6_Fq3 vv = v.squared();                // vv = v2
     const mnt6_Fq3 vvv = v*vv;                      // vvv = v*vv
-    const mnt6_Fq3 R = vv * this->X_;               // R = vv*X1
-    const mnt6_Fq3 A = uu * this->Z_ - vvv - R - R; // A = uu*Z1-vvv-2*R
+    const mnt6_Fq3 R = vv * this->X;               // R = vv*X1
+    const mnt6_Fq3 A = uu * this->Z - vvv - R - R; // A = uu*Z1-vvv-2*R
     const mnt6_Fq3 X3 = v * A;                      // X3 = v*A
-    const mnt6_Fq3 Y3 = u*(R-A) - vvv * this->Y_;   // Y3 = u*(R-A)-vvv*Y1
-    const mnt6_Fq3 Z3 = vvv * this->Z_;             // Z3 = vvv*Z1
+    const mnt6_Fq3 Y3 = u*(R-A) - vvv * this->Y;   // Y3 = u*(R-A)-vvv*Y1
+    const mnt6_Fq3 Z3 = vvv * this->Z;             // Z3 = vvv*Z1
 
     return mnt6_G2(X3, Y3, Z3);
 }
@@ -348,16 +348,16 @@ mnt6_G2 mnt6_G2::dbl() const
         // NOTE: does not handle O and pts of order 2,4
         // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-projective.html#doubling-dbl-2007-bl
 
-        const mnt6_Fq3 XX   = (this->X_).squared();                   // XX  = X1^2
-        const mnt6_Fq3 ZZ   = (this->Z_).squared();                   // ZZ  = Z1^2
+        const mnt6_Fq3 XX   = (this->X).squared();                   // XX  = X1^2
+        const mnt6_Fq3 ZZ   = (this->Z).squared();                   // ZZ  = Z1^2
         const mnt6_Fq3 w    = mnt6_G2::mul_by_a(ZZ) + (XX + XX + XX); // w   = a*ZZ + 3*XX
-        const mnt6_Fq3 Y1Z1 = (this->Y_) * (this->Z_);
+        const mnt6_Fq3 Y1Z1 = (this->Y) * (this->Z);
         const mnt6_Fq3 s    = Y1Z1 + Y1Z1;                            // s   = 2*Y1*Z1
         const mnt6_Fq3 ss   = s.squared();                            // ss  = s^2
         const mnt6_Fq3 sss  = s * ss;                                 // sss = s*ss
-        const mnt6_Fq3 R    = (this->Y_) * s;                         // R   = Y1*s
+        const mnt6_Fq3 R    = (this->Y) * s;                         // R   = Y1*s
         const mnt6_Fq3 RR   = R.squared();                            // RR  = R^2
-        const mnt6_Fq3 B    = ((this->X_)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
+        const mnt6_Fq3 B    = ((this->X)+R).squared()-XX-RR;         // B   = (X1+R)^2 - XX - RR
         const mnt6_Fq3 h    = w.squared() - (B+B);                    // h   = w^2-2*B
         const mnt6_Fq3 X3   = h * s;                                  // X3  = h*s
         const mnt6_Fq3 Y3   = w * (B-h)-(RR+RR);                      // Y3  = w*(B-h) - 2*RR
@@ -369,9 +369,9 @@ mnt6_G2 mnt6_G2::dbl() const
 
 mnt6_G2 mnt6_G2::mul_by_q() const
 {
-    return mnt6_G2(mnt6_twist_mul_by_q_X * (this->X_).Frobenius_map(1),
-                   mnt6_twist_mul_by_q_Y * (this->Y_).Frobenius_map(1),
-                   (this->Z_).Frobenius_map(1));
+    return mnt6_G2(mnt6_twist_mul_by_q_X * (this->X).Frobenius_map(1),
+                   mnt6_twist_mul_by_q_Y * (this->Y).Frobenius_map(1),
+                   (this->Z).Frobenius_map(1));
 }
 
 bool mnt6_G2::is_well_formed() const
@@ -393,12 +393,12 @@ bool mnt6_G2::is_well_formed() const
 
           z (y^2 - b z^2) = x ( x^2 + a z^2)
         */
-        const mnt6_Fq3 X2 = this->X_.squared();
-        const mnt6_Fq3 Y2 = this->Y_.squared();
-        const mnt6_Fq3 Z2 = this->Z_.squared();
+        const mnt6_Fq3 X2 = this->X.squared();
+        const mnt6_Fq3 Y2 = this->Y.squared();
+        const mnt6_Fq3 Z2 = this->Z.squared();
         const mnt6_Fq3 aZ2 = mnt6_twist_coeff_a * Z2;
 
-        return (this->Z_ * (Y2 - mnt6_twist_coeff_b * Z2) == this->X_ * (X2 + aZ2));
+        return (this->Z * (Y2 - mnt6_twist_coeff_b * Z2) == this->X * (X2 + aZ2));
     }
 }
 
@@ -424,10 +424,10 @@ std::ostream& operator<<(std::ostream &out, const mnt6_G2 &g)
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
 #ifdef NO_PT_COMPRESSION
-    out << copy.X_ << OUTPUT_SEPARATOR << copy.Y_;
+    out << copy.X << OUTPUT_SEPARATOR << copy.Y;
 #else
     /* storing LSB of Y */
-    out << copy.X_ << OUTPUT_SEPARATOR << (copy.Y_.c0.as_bigint().data[0] & 1);
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
 #endif
 
     return out;
@@ -468,9 +468,9 @@ std::istream& operator>>(std::istream &in, mnt6_G2 &g)
     // using projective coordinates
     if (!is_zero)
     {
-        g.X_ = tX;
-        g.Y_ = tY;
-        g.Z_ = mnt6_Fq3::one();
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt6_Fq3::one();
     }
     else
     {
@@ -487,7 +487,7 @@ void mnt6_G2::batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec)
 
     for (auto &el: vec)
     {
-        Z_vec.emplace_back(el.Z());
+        Z_vec.emplace_back(el.Z);
     }
     batch_invert<mnt6_Fq3>(Z_vec);
 
@@ -495,7 +495,7 @@ void mnt6_G2::batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec)
 
     for (size_t i = 0; i < vec.size(); ++i)
     {
-        vec[i] = mnt6_G2(vec[i].X() * Z_vec[i], vec[i].Y() * Z_vec[i], one);
+        vec[i] = mnt6_G2(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
 }
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp
@@ -24,8 +24,6 @@ std::ostream& operator<<(std::ostream &, const mnt6_G2&);
 std::istream& operator>>(std::istream &, mnt6_G2&);
 
 class mnt6_G2 {
-private:
-    mnt6_Fq3 X_, Y_, Z_;
 public:
 #ifdef PROFILE_OP_COUNTS
     static long long add_cnt;
@@ -43,13 +41,11 @@ public:
     typedef mnt6_Fq3 twist_field;
     typedef mnt6_Fr scalar_field;
 
+    mnt6_Fq3 X, Y, Z;
+
     // using projective coordinates
     mnt6_G2();
-    mnt6_G2(const mnt6_Fq3& X, const mnt6_Fq3& Y, const mnt6_Fq3& Z) : X_(X), Y_(Y), Z_(Z) {}
-
-    mnt6_Fq3 X() const { return X_; }
-    mnt6_Fq3 Y() const { return Y_; }
-    mnt6_Fq3 Z() const { return Z_; }
+    mnt6_G2(const mnt6_Fq3& X, const mnt6_Fq3& Y, const mnt6_Fq3& Z) : X(X), Y(Y), Z(Z) {}
 
     static mnt6_Fq3 mul_by_a(const mnt6_Fq3 &elt);
     static mnt6_Fq3 mul_by_b(const mnt6_Fq3 &elt);

--- a/libff/algebra/curves/mnt/mnt6/mnt6_pairing.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_pairing.cpp
@@ -237,9 +237,9 @@ mnt6_affine_ate_G1_precomputation mnt6_affine_ate_precompute_G1(const mnt6_G1& P
     Pcopy.to_affine_coordinates();
 
     mnt6_affine_ate_G1_precomputation result;
-    result.PX = Pcopy.X();
-    result.PY = Pcopy.Y();
-    result.PY_twist_squared = Pcopy.Y() * mnt6_twist.squared();
+    result.PX = Pcopy.X;
+    result.PY = Pcopy.Y;
+    result.PY_twist_squared = Pcopy.Y * mnt6_twist.squared();
 
     leave_block("Call to mnt6_affine_ate_precompute_G1");
     return result;
@@ -253,11 +253,11 @@ mnt6_affine_ate_G2_precomputation mnt6_affine_ate_precompute_G2(const mnt6_G2& Q
     Qcopy.to_affine_coordinates();
 
     mnt6_affine_ate_G2_precomputation result;
-    result.QX = Qcopy.X();
-    result.QY = Qcopy.Y();
+    result.QX = Qcopy.X;
+    result.QY = Qcopy.Y;
 
-    mnt6_Fq3 RX = Qcopy.X();
-    mnt6_Fq3 RY = Qcopy.Y();
+    mnt6_Fq3 RX = Qcopy.X;
+    mnt6_Fq3 RY = Qcopy.Y;
 
     const bigint<mnt6_Fr::num_limbs> &loop_count = mnt6_ate_loop_count;
     bool found_nonzero = false;
@@ -477,10 +477,10 @@ mnt6_ate_G1_precomp mnt6_ate_precompute_G1(const mnt6_G1& P)
     Pcopy.to_affine_coordinates();
 
     mnt6_ate_G1_precomp result;
-    result.PX = Pcopy.X();
-    result.PY = Pcopy.Y();
-    result.PX_twist = Pcopy.X() * mnt6_twist;
-    result.PY_twist = Pcopy.Y() * mnt6_twist;
+    result.PX = Pcopy.X;
+    result.PY = Pcopy.Y;
+    result.PX_twist = Pcopy.X * mnt6_twist;
+    result.PY_twist = Pcopy.Y * mnt6_twist;
 
     leave_block("Call to mnt6_ate_precompute_G1");
     return result;
@@ -496,15 +496,15 @@ mnt6_ate_G2_precomp mnt6_ate_precompute_G2(const mnt6_G2& Q)
     mnt6_Fq3 mnt6_twist_inv = mnt6_twist.inverse(); // could add to global params if needed
 
     mnt6_ate_G2_precomp result;
-    result.QX = Qcopy.X();
-    result.QY = Qcopy.Y();
-    result.QY2 = Qcopy.Y().squared();
-    result.QX_over_twist = Qcopy.X() * mnt6_twist_inv;
-    result.QY_over_twist = Qcopy.Y() * mnt6_twist_inv;
+    result.QX = Qcopy.X;
+    result.QY = Qcopy.Y;
+    result.QY2 = Qcopy.Y.squared();
+    result.QX_over_twist = Qcopy.X * mnt6_twist_inv;
+    result.QY_over_twist = Qcopy.Y * mnt6_twist_inv;
 
     extended_mnt6_G2_projective R;
-    R.X = Qcopy.X();
-    R.Y = Qcopy.Y();
+    R.X = Qcopy.X;
+    R.Y = Qcopy.Y;
     R.Z = mnt6_Fq3::one();
     R.T = mnt6_Fq3::one();
 


### PR DESCRIPTION
On the current master branch, the interfaces of the various curves are not consistent.
This is problematic as we cannot write code that would work for all curves and be generic.

This issue has to deal with how coordinates are managed in all curves implementations.
There are 5 curves implementations:
- alt_bn128
- bn128
- mnt4 and 6
- edwards

All these implementations follow different approaches to represent and access the points coordinates:
- alt_bn128: Point coordinates are public attributes `X, Y, Z` (see: https://github.com/scipr-lab/libff/blob/master/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp#L35)
- bn128: Point coordinates are stored in a public attribute `coord` which is an array of 3 elements (see: https://github.com/scipr-lab/libff/blob/master/libff/algebra/curves/bn128/bn128_g1.hpp#L36)
- edwards: Point coordinates are public attributes `X, Y, Z` (see: https://github.com/scipr-lab/libff/blob/master/libff/algebra/curves/edwards/edwards_g1.hpp#L32)
- mnt4/6: Point coordinates are **private attributes** `X_, Y_, Z_`, with getters `X(), Y(), Z()` (see: https://github.com/scipr-lab/libff/blob/master/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp#L49-L51 and https://github.com/scipr-lab/libff/blob/master/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp#L27-L28)

(Note that the comment above only links to the groups G1, but the same applies for the G2 groups).

As such, we see that there are 3 different methods used to handle the point coordinates.
This is problematic since we cannot easily switch "one curve for another" and write generic code. 

An example of affected project is: https://github.com/clearmatics/zeth, especially the functions here: https://github.com/clearmatics/zeth/pull/181/files

This PR fixes the above issue by refactoring the groups interfaces consistently. The convention followed is the one of the `alt_bn128` and `edwards` curves where the point coordinates are public attributes called `X, Y, Z`.

**Important note1:** This is a breaking change.
**Important note2:** I haven't ran benchmarks for this change. I suspect that the bn128 arithmetic may be a tiny bit affected by the changes as we need to pay the cost of filling the coordinate arrays before calling the functions from the namespace `bn::ecop`. This should be negligible compared to the actual "curve arithmetic" though.