### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,10 @@ compiler:
 os:
   - linux
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-5
-      - g++-5
-
 before_install:
-  - sudo apt-get install build-essential git libboost-all-dev cmake libgmp3-dev libssl-dev libprocps3-dev pkg-config
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get -q update
+  - sudo apt-get install build-essential git libboost-all-dev cmake libgmp3-dev libssl-dev libprocps3-dev pkg-config gcc-5 g++-5
 
 before_script:
   - git submodule init && git submodule update


### PR DESCRIPTION
Travis seems to have suddenly started failing recently, due to:
> Disallowing sources: ubuntu-toolchain-r-test

This change changes the travis file to manually add the source and install gcc-5 packages as described in https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-from-a-custom-apt-repository
