### PR TITLE
Compile warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 before_script:
   - git submodule init && git submodule update
-  - mkdir build && cd build && cmake ..
+  - mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror" ..
 
 script:
   - make

--- a/libff/algebra/curves/edwards/edwards_g2.cpp
+++ b/libff/algebra/curves/edwards/edwards_g2.cpp
@@ -114,7 +114,7 @@ void edwards_G2::to_special()
         return;
     }
 
-#ifdef DEBUG
+#if defined(DEBUG) && !defined(NDEBUG)
     const edwards_G2 copy(*this);
 #endif
 

--- a/libff/algebra/curves/tests/test_bilinearity.cpp
+++ b/libff/algebra/curves/tests/test_bilinearity.cpp
@@ -4,6 +4,13 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
+
+// If NDEBUG is defined, assert turns into nothing. No checks are made and a
+// lot of warnings are generated.
+#ifdef NDEBUG
+# undef NDEBUG
+#endif
+
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
 #include <libff/common/profiling.hpp>
 #ifdef CURVE_BN128

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -4,6 +4,13 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
+
+// If NDEBUG is defined, assert turns into nothing. No checks are made and a
+// lot of warnings are generated.
+#ifdef NDEBUG
+# undef NDEBUG
+#endif
+
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
@@ -11,9 +18,9 @@
 #ifdef CURVE_BN128
 #include <libff/algebra/curves/bn128/bn128_pp.hpp>
 #endif
-#include <sstream>
-
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
+
+#include <sstream>
 
 using namespace libff;
 

--- a/libff/algebra/fields/tests/test_fields.cpp
+++ b/libff/algebra/fields/tests/test_fields.cpp
@@ -4,6 +4,13 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
+
+// If NDEBUG is defined, assert turns into nothing. No checks are made and a
+// lot of warnings are generated.
+#ifdef NDEBUG
+# undef NDEBUG
+#endif
+
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -136,6 +136,7 @@ T multi_exp_inner(
         result = result + opt_window_wnaf_exp(*vec_it, scalar_bigint, scalar_bigint.num_bits());
     }
     assert(scalar_it == scalar_end);
+    UNUSED(scalar_end);
 
     return result;
 }
@@ -158,6 +159,7 @@ T multi_exp_inner(
         result = result + (*scalar_it) * (*vec_it);
     }
     assert(scalar_it == scalar_end);
+    UNUSED(scalar_end);
 
     return result;
 }

--- a/libff/common/double.cpp
+++ b/libff/common/double.cpp
@@ -19,177 +19,175 @@
 
 namespace libff {
 
-  const double PI = 3.141592653589793238460264338328L;
-
-  Double::Double()
-  {
+Double::Double()
+{
     val = std::complex<double>(0, 0);
-  }
+}
 
-  Double::Double(double real)
-  {
+Double::Double(double real)
+{
     val = std::complex<double>(real, 0);
-  }
+}
 
-  Double::Double(double real, double imag)
-  {
+Double::Double(double real, double imag)
+{
     val = std::complex<double>(real, imag);
-  }
+}
 
-  Double::Double(std::complex<double> num)
-  {
+Double::Double(std::complex<double> num)
+{
     val = num;
-  }
+}
 
-  unsigned Double::add_cnt = 0;
-  unsigned Double::sub_cnt = 0;
-  unsigned Double::mul_cnt = 0;
-  unsigned Double::inv_cnt = 0;
+unsigned Double::add_cnt = 0;
+unsigned Double::sub_cnt = 0;
+unsigned Double::mul_cnt = 0;
+unsigned Double::inv_cnt = 0;
 
-  Double Double::operator+(const Double &other) const
-  {
+Double Double::operator+(const Double &other) const
+{
 #ifdef PROFILE_OP_COUNTS
     ++add_cnt;
 #endif
 
     return Double(val + other.val);
-  }
+}
 
-  Double Double::operator-(const Double &other) const
-  {
+Double Double::operator-(const Double &other) const
+{
 #ifdef PROFILE_OP_COUNTS
     ++sub_cnt;
 #endif
 
     return Double(val - other.val);
-  }
+}
 
-  Double Double::operator*(const Double &other) const
-  {
+Double Double::operator*(const Double &other) const
+{
 #ifdef PROFILE_OP_COUNTS
     ++mul_cnt;
 #endif
 
     return Double(val * other.val);
-  }
+}
 
-  Double Double::operator-() const
-  {
+Double Double::operator-() const
+{
     if (val.imag() == 0) return Double(-val.real());
 
     return Double(-val.real(), -val.imag());
-  }
+}
 
-  Double& Double::operator+=(const Double &other)
-  {
+Double& Double::operator+=(const Double &other)
+{
 #ifdef PROFILE_OP_COUNTS
     ++add_cnt;
 #endif
 
     this->val = std::complex<double>(val + other.val);
     return *this;
-  }
+}
 
-  Double& Double::operator-=(const Double &other)
-  {
+Double& Double::operator-=(const Double &other)
+{
 #ifdef PROFILE_OP_COUNTS
     ++sub_cnt;
 #endif
 
     this->val = std::complex<double>(val - other.val);
     return *this;
-  }
+}
 
-  Double& Double::operator*=(const Double &other)
-  {
+Double& Double::operator*=(const Double &other)
+{
 #ifdef PROFILE_OP_COUNTS
     ++mul_cnt;
 #endif
 
     this->val *= std::complex<double>(other.val);
     return *this;
-  }
+}
 
-  bool Double::operator==(const Double &other) const
-  {
+bool Double::operator==(const Double &other) const
+{
     return (std::abs(val.real() - other.val.real()) < 0.000001)
         && (std::abs(val.imag() - other.val.imag()) < 0.000001);
-  }
+}
 
-  bool Double::operator!=(const Double &other) const
-  {
+bool Double::operator!=(const Double &other) const
+{
     return Double(val) == other ? 0 : 1;
-  }
+}
 
-  bool Double::operator<(const Double &other) const
-  {
+bool Double::operator<(const Double &other) const
+{
     return (val.real() < other.val.real());
-  }
+}
 
-  bool Double::operator>(const Double &other) const
-  {
+bool Double::operator>(const Double &other) const
+{
     return (val.real() > other.val.real());
-  }
+}
 
-  Double Double::operator^(const libff::bigint<1> power) const
-  {
+Double Double::operator^(const libff::bigint<1> power) const
+{
     return Double(pow(val, power.as_ulong()));
-  }
+}
 
-  Double Double::operator^(const size_t power) const
-  {
+Double Double::operator^(const size_t power) const
+{
     return Double(pow(val, power));
-  }
+}
 
-  Double Double::inverse() const
-  {
+Double Double::inverse() const
+{
 #ifdef PROFILE_OP_COUNTS
     ++inv_cnt;
 #endif
 
     return Double(std::complex<double>(1) / val);
-  }
+}
 
-  libff::bigint<1> Double::as_bigint() const
-  {
+libff::bigint<1> Double::as_bigint() const
+{
     return libff::bigint<1>(val.real());
-  }
+}
 
-  unsigned long Double::as_ulong() const
-  {
+unsigned long Double::as_ulong() const
+{
     return round(val.real());
-  }
+}
 
-  Double Double::squared() const
-  {
+Double Double::squared() const
+{
     return Double(val * val);
-  }
+}
 
-  Double Double::one()
-  {
+Double Double::one()
+{
     return Double(1);
-  }
+}
 
-  Double Double::zero()
-  {
+Double Double::zero()
+{
     return Double(0);
-  }
+}
 
-  Double Double::random_element()
-  {
+Double Double::random_element()
+{
     return Double(std::rand() % 1001);
-  }
+}
 
-  Double Double::geometric_generator()
-  {
+Double Double::geometric_generator()
+{
     return Double(2);
-  }
+}
 
-  Double Double::arithmetic_generator()
-  {
+Double Double::arithmetic_generator()
+{
     return Double(1);
-  }
+}
 
-  Double Double::multiplicative_generator = Double(2);
+Double Double::multiplicative_generator = Double(2);
 
 } // libff

--- a/libff/common/profiling.cpp
+++ b/libff/common/profiling.cpp
@@ -344,6 +344,7 @@ void print_mem(const std::string &s)
         printf("* Peak vsize (physical memory+swap) in mebibytes (%s): %lu\n", s.c_str(), usage.vsize >> 20);
     }
 #else
+    UNUSED(s);
     printf("* Memory profiling not supported in NO_PROCPS mode\n");
 #endif
 }


### PR DESCRIPTION
Fix some compile warnings thrown up by newer compilers.
Also enabled the test asserts in release builds (in lieu of using a test framework).
