### PR TITLE
Support compressed and uncompressed point serialization

### DIFF
--- a/libff/algebra/curves/alt_bn128/alt_bn128_g1.cpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g1.cpp
@@ -405,31 +405,51 @@ alt_bn128_G1 alt_bn128_G1::random_element()
     return (scalar_field::random_element().as_bigint()) * G1_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const alt_bn128_G1 &g)
+void alt_bn128_G1::write_uncompressed(std::ostream &out) const
 {
-    alt_bn128_G1 copy(g);
+    alt_bn128_G1 copy(*this);
     copy.to_affine_coordinates();
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, alt_bn128_G1 &g)
+void alt_bn128_G1::write_compressed(std::ostream &out) const
+{
+    alt_bn128_G1 copy(*this);
+    copy.to_affine_coordinates();
+
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
+}
+
+void alt_bn128_G1::read_uncompressed(std::istream &in, alt_bn128_G1 &g)
 {
     char is_zero;
     alt_bn128_Fq tX, tY;
 
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using Jacobian coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = alt_bn128_Fq::one();
+    }
+    else
+    {
+        g = alt_bn128_G1::zero();
+    }
+}
+
+void alt_bn128_G1::read_compressed(std::istream &in, alt_bn128_G1 &g)
+{
+    char is_zero;
+    alt_bn128_Fq tX, tY;
+
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -452,7 +472,7 @@ std::istream& operator>>(std::istream &in, alt_bn128_G1 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using Jacobian coordinates
     if (!is_zero)
     {
@@ -464,39 +484,25 @@ std::istream& operator>>(std::istream &in, alt_bn128_G1 &g)
     {
         g = alt_bn128_G1::zero();
     }
-
-    return in;
 }
 
-std::ostream& operator<<(std::ostream& out, const std::vector<alt_bn128_G1> &v)
+std::ostream& operator<<(std::ostream &out, const alt_bn128_G1 &g)
 {
-    out << v.size() << "\n";
-    for (const alt_bn128_G1& t : v)
-    {
-        out << t << OUTPUT_NEWLINE;
-    }
-
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
     return out;
 }
 
-std::istream& operator>>(std::istream& in, std::vector<alt_bn128_G1> &v)
+std::istream& operator>>(std::istream &in, alt_bn128_G1 &g)
 {
-    v.clear();
-
-    size_t s;
-    in >> s;
-    consume_newline(in);
-
-    v.reserve(s);
-
-    for (size_t i = 0; i < s; ++i)
-    {
-        alt_bn128_G1 g;
-        in >> g;
-        consume_OUTPUT_NEWLINE(in);
-        v.emplace_back(g);
-    }
-
+#ifdef NO_PT_COMPRESSION
+    alt_bn128_G1::read_uncompressed(in, g);
+#else
+    alt_bn128_G1::read_compressed(in, g);
+#endif
     return in;
 }
 

--- a/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp
@@ -69,8 +69,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const alt_bn128_G1 &g);
-    friend std::istream& operator>>(std::istream &in, alt_bn128_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, alt_bn128_G1 &);
+    static void read_compressed(std::istream &, alt_bn128_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<alt_bn128_G1> &vec);
 };
@@ -86,9 +88,6 @@ alt_bn128_G1 operator*(const Fp_model<m,modulus_p> &lhs, const alt_bn128_G1 &rhs
 {
     return scalar_mul<alt_bn128_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<alt_bn128_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<alt_bn128_G1> &v);
 
 } // libff
 #endif // ALT_BN128_G1_HPP_

--- a/libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp
@@ -73,8 +73,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const alt_bn128_G2 &g);
-    friend std::istream& operator>>(std::istream &in, alt_bn128_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, alt_bn128_G2 &);
+    static void read_compressed(std::istream &, alt_bn128_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<alt_bn128_G2> &vec);
 };

--- a/libff/algebra/curves/bn128/bn128_g1.hpp
+++ b/libff/algebra/curves/bn128/bn128_g1.hpp
@@ -73,8 +73,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const bn128_G1 &g);
-    friend std::istream& operator>>(std::istream &in, bn128_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, bn128_G1 &);
+    static void read_compressed(std::istream &, bn128_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<bn128_G1> &vec);
 };
@@ -90,10 +92,6 @@ bn128_G1 operator*(const Fp_model<m,modulus_p> &lhs, const bn128_G1 &rhs)
 {
     return scalar_mul<bn128_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<bn128_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<bn128_G1> &v);
-
 
 } // libff
 #endif // BN128_G1_HPP_

--- a/libff/algebra/curves/bn128/bn128_g2.hpp
+++ b/libff/algebra/curves/bn128/bn128_g2.hpp
@@ -74,8 +74,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const bn128_G2 &g);
-    friend std::istream& operator>>(std::istream &in, bn128_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, bn128_G2 &);
+    static void read_compressed(std::istream &, bn128_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<bn128_G2> &vec);
 };

--- a/libff/algebra/curves/edwards/edwards_g1.hpp
+++ b/libff/algebra/curves/edwards/edwards_g1.hpp
@@ -71,8 +71,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const edwards_G1 &g);
-    friend std::istream& operator>>(std::istream &in, edwards_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, edwards_G1 &);
+    static void read_compressed(std::istream &, edwards_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<edwards_G1> &vec);
 };
@@ -88,9 +90,6 @@ edwards_G1 operator*(const Fp_model<m,modulus_p> &lhs, const edwards_G1 &rhs)
 {
     return scalar_mul<edwards_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<edwards_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<edwards_G1> &v);
 
 } // libff
 #endif // EDWARDS_G1_HPP_

--- a/libff/algebra/curves/edwards/edwards_g2.hpp
+++ b/libff/algebra/curves/edwards/edwards_g2.hpp
@@ -77,8 +77,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const edwards_G2 &g);
-    friend std::istream& operator>>(std::istream &in, edwards_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, edwards_G2 &);
+    static void read_compressed(std::istream &, edwards_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<edwards_G2> &vec);
 };

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp
@@ -77,8 +77,10 @@ public:
     static bigint<mnt4_Fq::num_limbs> base_field_char() { return mnt4_Fq::field_char(); }
     static bigint<mnt4_Fr::num_limbs> order() { return mnt4_Fr::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const mnt4_G1 &g);
-    friend std::istream& operator>>(std::istream &in, mnt4_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, mnt4_G1 &);
+    static void read_compressed(std::istream &, mnt4_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<mnt4_G1> &vec);
 };
@@ -94,9 +96,6 @@ mnt4_G1 operator*(const Fp_model<m,modulus_p> &lhs, const mnt4_G1 &rhs)
 {
     return scalar_mul<mnt4_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<mnt4_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<mnt4_G1> &v);
 
 } // libff
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g2.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g2.cpp
@@ -414,31 +414,49 @@ mnt4_G2 mnt4_G2::random_element()
     return (mnt4_Fr::random_element().as_bigint()) * G2_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const mnt4_G2 &g)
+void mnt4_G2::write_uncompressed(std::ostream &out) const
 {
-    mnt4_G2 copy(g);
+    mnt4_G2 copy(*this);
     copy.to_affine_coordinates();
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, mnt4_G2 &g)
+void mnt4_G2::write_compressed(std::ostream &out) const
+{
+    mnt4_G2 copy(*this);
+    copy.to_affine_coordinates();
+
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
+}
+
+void mnt4_G2::read_uncompressed(std::istream &in, mnt4_G2 &g)
 {
     char is_zero;
     mnt4_Fq2 tX, tY;
-
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using projective coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt4_Fq2::one();
+    }
+    else
+    {
+        g = mnt4_G2::zero();
+    }
+}
+
+void mnt4_G2::read_compressed(std::istream &in, mnt4_G2 &g)
+{
+    char is_zero;
+    mnt4_Fq2 tX, tY;
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -461,7 +479,7 @@ std::istream& operator>>(std::istream &in, mnt4_G2 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using projective coordinates
     if (!is_zero)
     {
@@ -473,8 +491,6 @@ std::istream& operator>>(std::istream &in, mnt4_G2 &g)
     {
         g = mnt4_G2::zero();
     }
-
-    return in;
 }
 
 void mnt4_G2::batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec)
@@ -494,6 +510,26 @@ void mnt4_G2::batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec)
     {
         vec[i] = mnt4_G2(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
+}
+
+std::ostream& operator<<(std::ostream &out, const mnt4_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
+    return out;
+}
+
+std::istream& operator>>(std::istream &in, mnt4_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    mnt4_G2::read_uncompressed(in, g);
+#else
+    mnt4_G2::read_compressed(in, g);
+#endif
+    return in;
 }
 
 } // libff

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp
@@ -82,8 +82,10 @@ public:
     static bigint<mnt4_Fq::num_limbs> base_field_char() { return mnt4_Fq::field_char(); }
     static bigint<mnt4_Fr::num_limbs> order() { return mnt4_Fr::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const mnt4_G2 &g);
-    friend std::istream& operator>>(std::istream &in, mnt4_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, mnt4_G2 &);
+    static void read_compressed(std::istream &, mnt4_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec);
 };

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g1.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g1.cpp
@@ -390,31 +390,49 @@ mnt6_G1 mnt6_G1::random_element()
     return (scalar_field::random_element().as_bigint()) * G1_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const mnt6_G1 &g)
+void mnt6_G1::write_uncompressed(std::ostream &out) const
 {
-    mnt6_G1 copy(g);
+    mnt6_G1 copy(*this);
     copy.to_affine_coordinates();
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, mnt6_G1 &g)
+void mnt6_G1::write_compressed(std::ostream &out) const
+{
+    mnt6_G1 copy(*this);
+    copy.to_affine_coordinates();
+
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
+}
+
+void mnt6_G1::read_uncompressed(std::istream &in, mnt6_G1 &g)
 {
     char is_zero;
     mnt6_Fq tX, tY;
-
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using projective coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt6_Fq::one();
+    }
+    else
+    {
+        g = mnt6_G1::zero();
+    }
+}
+
+void mnt6_G1::read_compressed(std::istream &in, mnt6_G1 &g)
+{
+    char is_zero;
+    mnt6_Fq tX, tY;
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -437,7 +455,7 @@ std::istream& operator>>(std::istream &in, mnt6_G1 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using projective coordinates
     if (!is_zero)
     {
@@ -449,40 +467,6 @@ std::istream& operator>>(std::istream &in, mnt6_G1 &g)
     {
         g = mnt6_G1::zero();
     }
-
-    return in;
-}
-
-std::ostream& operator<<(std::ostream& out, const std::vector<mnt6_G1> &v)
-{
-    out << v.size() << "\n";
-    for (const mnt6_G1& t : v)
-    {
-        out << t << OUTPUT_NEWLINE;
-    }
-
-    return out;
-}
-
-std::istream& operator>>(std::istream& in, std::vector<mnt6_G1> &v)
-{
-    v.clear();
-
-    size_t s;
-    in >> s;
-    consume_newline(in);
-
-    v.reserve(s);
-
-    for (size_t i = 0; i < s; ++i)
-    {
-        mnt6_G1 g;
-        in >> g;
-        consume_OUTPUT_NEWLINE(in);
-        v.emplace_back(g);
-    }
-
-    return in;
 }
 
 void mnt6_G1::batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec)
@@ -502,6 +486,26 @@ void mnt6_G1::batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec)
     {
         vec[i] = mnt6_G1(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
+}
+
+std::ostream& operator<<(std::ostream &out, const mnt6_G1 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
+    return out;
+}
+
+std::istream& operator>>(std::istream &in, mnt6_G1 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    mnt6_G1::read_uncompressed(in, g);
+#else
+    mnt6_G1::read_compressed(in, g);
+#endif
+    return in;
 }
 
 } // libff

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp
@@ -77,8 +77,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const mnt6_G1 &g);
-    friend std::istream& operator>>(std::istream &in, mnt6_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, mnt6_G1 &);
+    static void read_compressed(std::istream &, mnt6_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec);
 };
@@ -94,9 +96,6 @@ mnt6_G1 operator*(const Fp_model<m,modulus_p> &lhs, const mnt6_G1 &rhs)
 {
     return scalar_mul<mnt6_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<mnt6_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<mnt6_G1> &v);
 
 } // libff
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g2.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g2.cpp
@@ -421,31 +421,51 @@ mnt6_G2 mnt6_G2::random_element()
     return (mnt6_Fr::random_element().as_bigint()) * G2_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const mnt6_G2 &g)
+void mnt6_G2::write_uncompressed(std::ostream &out) const
 {
-    mnt6_G2 copy(g);
+    mnt6_G2 copy(*this);
     copy.to_affine_coordinates();
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, mnt6_G2 &g)
+void mnt6_G2::write_compressed(std::ostream &out) const
+{
+    mnt6_G2 copy(*this);
+    copy.to_affine_coordinates();
+
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
+}
+
+void mnt6_G2::read_uncompressed(std::istream &in, mnt6_G2 &g)
 {
     char is_zero;
     mnt6_Fq3 tX, tY;
 
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using projective coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt6_Fq3::one();
+    }
+    else
+    {
+        g = mnt6_G2::zero();
+    }
+}
+
+void mnt6_G2::read_compressed(std::istream &in, mnt6_G2 &g)
+{
+    char is_zero;
+    mnt6_Fq3 tX, tY;
+
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -468,7 +488,7 @@ std::istream& operator>>(std::istream &in, mnt6_G2 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using projective coordinates
     if (!is_zero)
     {
@@ -480,8 +500,6 @@ std::istream& operator>>(std::istream &in, mnt6_G2 &g)
     {
         g = mnt6_G2::zero();
     }
-
-    return in;
 }
 
 void mnt6_G2::batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec)
@@ -501,6 +519,26 @@ void mnt6_G2::batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec)
     {
         vec[i] = mnt6_G2(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
+}
+
+std::ostream& operator<<(std::ostream &out, const mnt6_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
+    return out;
+}
+
+std::istream& operator>>(std::istream &in, mnt6_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    mnt6_G2::read_uncompressed(in, g);
+#else
+    mnt6_G2::read_compressed(in, g);
+#endif
+    return in;
 }
 
 } // libff

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp
@@ -82,8 +82,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const mnt6_G2 &g);
-    friend std::istream& operator>>(std::istream &in, mnt6_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, mnt6_G2 &);
+    static void read_compressed(std::istream &, mnt6_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec);
 };

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -129,9 +129,19 @@ void test_output()
     {
         std::stringstream ss;
         ss << g;
+        g.write_compressed(ss);
+        g.write_uncompressed(ss);
+
         GroupT gg;
+        GroupT gg_comp;
+        GroupT gg_uncomp;
         ss >> gg;
+        GroupT::read_compressed(ss, gg_comp);
+        GroupT::read_uncompressed(ss, gg_uncomp);
+
         assert(g == gg);
+        assert(g == gg_comp);
+        assert(g == gg_uncomp);
         /* use a random point in next iteration */
         g = GroupT::random_element();
     }


### PR DESCRIPTION
Allows compressed / uncompressed points to be used in different situations, independently of the build configuration.