### PR TITLE
Add Mac os compilation instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ option(
 option(
   WITH_PROCPS
   "Use procps for memory profiling"
-  ON
+  OFF
 )
 
 option(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ option(
   OFF
 )
 
+# This option does not work on macOS, since there is no /proc
 option(
   WITH_PROCPS
   "Use procps for memory profiling"
@@ -116,6 +117,9 @@ find_package(OpenSSL REQUIRED)
 INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR})
 
 if("${WITH_PROCPS}")
+  if(APPLE)
+    message(WARNING "WITH_PROCPS must be set to OFF for macOS build")
+  endif()
   include(FindPkgConfig)
   pkg_check_modules(
     PROCPS

--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ git submodule init && git submodule update
 To compile, starting at the project root directory, create the build directory and Makefile:
 
 ```
-mkdir build && cd build && cmake ..
+mkdir build && cd build
+cmake ..
 ```
+If you are on mac os, change the cmake command to be `cmake .. -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl`
+
 Optionally, you can specify the install location by providing the desired install path prefix:
 ```
 cmake .. -DCMAKE_INSTALL_PREFIX=/install/path

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To compile, starting at the project root directory, create the build directory a
 mkdir build && cd build
 cmake ..
 ```
-If you are on mac os, change the cmake command to be `cmake .. -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl`
+If you are on macOS, change the cmake command to be `cmake .. -DOPENSSL_ROOT_DIR=$(brew --prefix openssl)`
 
 Optionally, you can specify the install location by providing the desired install path prefix:
 ```


### PR DESCRIPTION
This changes the `with procps` flag to be default to off, and adds instructions to the README for the flag for where to locate openssl. (Alternatively we can adapt the FindOpenSSL.cmake script)