### PR TITLE
remove "depends/" prefix from include directives in bn128

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ add_definitions(
 enable_testing()
 
 if(${CURVE} STREQUAL "BN128")
+  include_directories(depends)
   add_definitions(
     -DBN_SUPPORT_SNARK=1
   )

--- a/libff/CMakeLists.txt
+++ b/libff/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(FF_EXTRASRCS)
 set(FF_EXTRALIBS)
 if(${CURVE} STREQUAL "BN128")
+  include_directories(depends)
   set(
     FF_EXTRASRCS
 

--- a/libff/algebra/curves/bn128/bn128_g1.hpp
+++ b/libff/algebra/curves/bn128/bn128_g1.hpp
@@ -9,7 +9,7 @@
 #define BN128_G1_HPP_
 #include <vector>
 
-#include "depends/ate-pairing/include/bn.h"
+#include "ate-pairing/include/bn.h"
 
 #include <libff/algebra/curves/bn128/bn128_init.hpp>
 #include <libff/algebra/curves/curve_utils.hpp>

--- a/libff/algebra/curves/bn128/bn128_g2.hpp
+++ b/libff/algebra/curves/bn128/bn128_g2.hpp
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <vector>
 
-#include "depends/ate-pairing/include/bn.h"
+#include "ate-pairing/include/bn.h"
 
 #include <libff/algebra/curves/bn128/bn128_init.hpp>
 #include <libff/algebra/curves/curve_utils.hpp>

--- a/libff/algebra/curves/bn128/bn128_gt.hpp
+++ b/libff/algebra/curves/bn128/bn128_gt.hpp
@@ -9,7 +9,7 @@
 #define BN128_GT_HPP_
 #include <iostream>
 
-#include "depends/ate-pairing/include/bn.h"
+#include "ate-pairing/include/bn.h"
 
 #include <libff/algebra/fields/field_utils.hpp>
 #include <libff/algebra/fields/fp.hpp>

--- a/libff/algebra/curves/bn128/bn128_init.hpp
+++ b/libff/algebra/curves/bn128/bn128_init.hpp
@@ -7,7 +7,7 @@
 
 #ifndef BN128_INIT_HPP_
 #define BN128_INIT_HPP_
-#include "depends/ate-pairing/include/bn.h"
+#include "ate-pairing/include/bn.h"
 
 #include <libff/algebra/curves/public_params.hpp>
 #include <libff/algebra/fields/fp.hpp>

--- a/libff/algebra/curves/bn128/bn128_pairing.hpp
+++ b/libff/algebra/curves/bn128/bn128_pairing.hpp
@@ -10,7 +10,7 @@
 
 #ifndef BN128_PAIRING_HPP_
 #define BN128_PAIRING_HPP_
-#include "depends/ate-pairing/include/bn.h"
+#include "ate-pairing/include/bn.h"
 
 #include <libff/algebra/curves/bn128/bn128_g1.hpp>
 #include <libff/algebra/curves/bn128/bn128_g2.hpp>

--- a/libff/algebra/curves/bn128/bn_utils.hpp
+++ b/libff/algebra/curves/bn128/bn_utils.hpp
@@ -9,7 +9,7 @@
 #define BN_UTILS_HPP_
 #include <vector>
 
-#include "depends/ate-pairing/include/bn.h"
+#include "ate-pairing/include/bn.h"
 
 namespace libff {
 


### PR DESCRIPTION
* ate-pairing is not part of libff, it's a dependency. using "depends"
in include directives forces lib users to support a particular build
structure, namely one that uses a "depends" subdirectory.  this is undesireable.