### PR TITLE
Fix bit checking when sizeof(mp_limb_t) != sizeof(unsigned long)

### DIFF
--- a/libff/algebra/fields/fp.tcc
+++ b/libff/algebra/fields/fp.tcc
@@ -733,7 +733,8 @@ Fp_model<n, modulus> Fp_model<n,modulus>::random_element() /// returns random el
             const std::size_t part = bitno/GMP_NUMB_BITS;
             const std::size_t bit = bitno - (GMP_NUMB_BITS*part);
 
-            r.mont_repr.data[part] &= ~(1ul<<bit);
+            static const mp_limb_t one = 1;
+            r.mont_repr.data[part] &= ~(one<<bit);
 
             bitno--;
         }

--- a/libff/algebra/fields/fp12_2over3over2.tcc
+++ b/libff/algebra/fields/fp12_2over3over2.tcc
@@ -348,7 +348,8 @@ Fp12_2over3over2_model<n, modulus> Fp12_2over3over2_model<n,modulus>::cyclotomic
                 res = res.cyclotomic_squared();
             }
 
-            if (exponent.data[i] & (1ul<<j))
+            static const mp_limb_t one = 1;
+            if (exponent.data[i] & (one<<j))
             {
                 found_one = true;
                 res = res * (*this);

--- a/libff/common/rng.tcc
+++ b/libff/common/rng.tcc
@@ -57,7 +57,8 @@ FieldT SHA512_rng(const uint64_t idx)
             const std::size_t part = bitno/GMP_NUMB_BITS;
             const std::size_t bit = bitno - (GMP_NUMB_BITS*part);
 
-            rval.data[part] &= ~(1ul<<bit);
+            static const mp_limb_t one = 1;
+            rval.data[part] &= ~(one<<bit);
 
             bitno--;
         }


### PR DESCRIPTION
For instance, on Windows long is 32 bit, while long long is 64 bit