### PR TITLE
Did minor comment cleanup on staging for v1.1

### DIFF
--- a/libff/algebra/curves/tests/test_bilinearity.cpp
+++ b/libff/algebra/curves/tests/test_bilinearity.cpp
@@ -53,7 +53,8 @@ void pairing_test()
     assert(ans1 != GT_one);
     assert((ans1^Fr<ppT>::field_char()) == GT_one);
     printf("\n\n");
-    UNUSED(GT_one);  // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(GT_one);
 }
 
 template<typename ppT>
@@ -73,7 +74,8 @@ void double_miller_loop_test()
     const Fqk<ppT> ans_2 = ppT::miller_loop(prec_P2, prec_Q2);
     const Fqk<ppT> ans_12 = ppT::double_miller_loop(prec_P1, prec_Q1, prec_P2, prec_Q2);
     assert(ans_1 * ans_2 == ans_12);
-    UNUSED(ans_1);  // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(ans_1);
     UNUSED(ans_2);
     UNUSED(ans_12);
 }
@@ -110,7 +112,8 @@ void affine_pairing_test()
     assert(ans1 != GT_one);
     assert((ans1^Fr<ppT>::field_char()) == GT_one);
     printf("\n\n");
-    UNUSED(GT_one);  // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(GT_one);
 }
 
 int main(void)
@@ -134,7 +137,8 @@ int main(void)
     pairing_test<alt_bn128_pp>();
     double_miller_loop_test<alt_bn128_pp>();
 
-#ifdef CURVE_BN128       // BN128 has fancy dependencies so it may be disabled
+// BN128 has fancy dependencies so it may be disabled
+#ifdef CURVE_BN128
     bn128_pp::init_public_params();
     pairing_test<bn128_pp>();
     double_miller_loop_test<bn128_pp>();

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -131,7 +131,8 @@ void test_mul_by_q()
 {
     GroupT a = GroupT::random_element();
     assert((GroupT::base_field_char()*a) == a.mul_by_q());
-    UNUSED(a);  // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(a);
 }
 
 template<typename GroupT>
@@ -146,7 +147,7 @@ void test_output()
         GroupT gg;
         ss >> gg;
         assert(g == gg);
-        /* use a random point in next iteration */
+        // Use a random point in next iteration
         g = GroupT::random_element();
     }
 }
@@ -181,7 +182,8 @@ int main(void)
     test_output<G2<alt_bn128_pp> >();
     test_mul_by_q<G2<alt_bn128_pp> >();
 
-#ifdef CURVE_BN128       // BN128 has fancy dependencies so it may be disabled
+// BN128 has fancy dependencies so it may be disabled
+#ifdef CURVE_BN128
     bn128_pp::init_public_params();
     test_group<G1<bn128_pp> >();
     test_output<G1<bn128_pp> >();

--- a/libff/algebra/fields/tests/test_fields.cpp
+++ b/libff/algebra/fields/tests/test_fields.cpp
@@ -70,7 +70,8 @@ void test_sqrt()
         FieldT a = FieldT::random_element();
         FieldT asq = a.squared();
         assert(asq.sqrt() == a || asq.sqrt() == -a);
-        UNUSED(a);    // Prevent release build warnings
+        // Prevent release build warnings
+        UNUSED(a);
         UNUSED(asq);
     }
 }
@@ -82,7 +83,8 @@ void test_two_squarings()
     assert(a.squared() == a * a);
     assert(a.squared() == a.squared_complex());
     assert(a.squared() == a.squared_karatsuba());
-    UNUSED(a);    // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(a);
 }
 
 template<typename FieldT>
@@ -95,11 +97,13 @@ void test_Frobenius()
     {
         const FieldT a_qi = a.Frobenius_map(power);
         assert(a_qi == a_q);
-        UNUSED(a_qi);    // Prevent release build warnings
+        // Prevent release build warnings
+        UNUSED(a_qi);
 
         a_q = a_q ^ FieldT::base_field_char();
     }
-    UNUSED(a);    // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(a);
 }
 
 template<typename FieldT>
@@ -109,7 +113,8 @@ void test_unitary_inverse()
     FieldT a = FieldT::random_element();
     FieldT aqcubed_minus1 = a.Frobenius_map(FieldT::extension_degree()/2) * a.inverse();
     assert(aqcubed_minus1.inverse() == aqcubed_minus1.unitary_inverse());
-    UNUSED(aqcubed_minus1);  // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(aqcubed_minus1);
 }
 
 template<typename FieldT>
@@ -125,7 +130,8 @@ void test_cyclotomic_squaring<Fqk<edwards_pp> >()
     // beta = a^((q^(k/2)-1)*(q+1))
     FieldT beta = a_unitary.Frobenius_map(1) * a_unitary;
     assert(beta.cyclotomic_squared() == beta.squared());
-    UNUSED(beta);    // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(beta);
 }
 
 template<>
@@ -138,7 +144,8 @@ void test_cyclotomic_squaring<Fqk<mnt4_pp> >()
     // beta = a^(q^(k/2)-1)
     FieldT beta = a_unitary;
     assert(beta.cyclotomic_squared() == beta.squared());
-    UNUSED(beta);    // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(beta);
 }
 
 template<>
@@ -151,7 +158,8 @@ void test_cyclotomic_squaring<Fqk<mnt6_pp> >()
     // beta = a^((q^(k/2)-1)*(q+1))
     FieldT beta = a_unitary.Frobenius_map(1) * a_unitary;
     assert(beta.cyclotomic_squared() == beta.squared());
-    UNUSED(beta);    // Prevent release build warnings
+    // Prevent release build warnings
+    UNUSED(beta);
 }
 
 template<typename ppT>
@@ -218,7 +226,8 @@ void test_Fp4_tom_cook()
         c3 = FieldT(12).inverse() * (FieldT(5)*v0 - FieldT(7)*v1) - FieldT(24).inverse()*(v2 - FieldT(7)*v3 + v4 + v5) + FieldT(15)*v6;
 
         assert(res == correct_res);
-        UNUSED(correct_res);    // Prevent release build warnings
+        // Prevent release build warnings
+        UNUSED(correct_res);
 
         // {v0, v3, v4, v5}
         const FieldT u = (FieldT::one() - beta).inverse();
@@ -258,7 +267,8 @@ int main()
     test_Frobenius<alt_bn128_Fq6>();
     test_all_fields<alt_bn128_pp>();
 
-#ifdef CURVE_BN128       // BN128 has fancy dependencies so it may be disabled
+// BN128 has fancy dependencies so it may be disabled
+#ifdef CURVE_BN128
     bn128_pp::init_public_params();
     test_field<Fr<bn128_pp> >();
     test_field<Fq<bn128_pp> >();

--- a/libff/common/utils.cpp
+++ b/libff/common/utils.cpp
@@ -16,8 +16,10 @@
 
 namespace libff {
 
-/** Round n to the next power of two.
- *  If n is a power of two, return n  */
+/**
+ * Round n to the next power of two.
+ * If n is a power of two, return n
+ */
 size_t get_power_of_two(size_t n)
 {
     n--;


### PR DESCRIPTION
Did some minor comment re-arrangement on staging for the v1.1 PR. Some comments were written on the same line separated by 4 spaces, some were separated by 6 spaces, some were written on the line above. That was inconsistent so I just moved all comments on the line above (which is also nice to have if we want to configure tools like `clang-tidy` later on, as such tools may either complain or format our code in a weird way because the lines are too long due to the fact that comments are written on the same line etc..).

Additionally, I'd be in favor to be careful with comment blocks styles. In fact, we need to comply with a certain syntax is we want to use Doxygen down the line to generate the project's documentation: https://www.doxygen.nl/manual/docblocks.html

Related to #57 