### PR TITLE
Use std::size_t and fix indentation in common/ and algebra/scalar_multiplication/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Bug fixes
 - #75 Get rid of warning for unused constant PI, in complex field
 - #78 Reduce prints when inhibit_profiling_info is set
-- #79 Use std::size_t for all curves, fix bugs introduced by #58
+- #79 & #87 Use std::size_t for all code, fix bugs introduced by #58
 
 ## v1.1.0
 

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -1,14 +1,11 @@
 /** @file
  *****************************************************************************
-
  Declaration of interfaces for multi-exponentiation routines.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef MULTIEXP_HPP_
 #define MULTIEXP_HPP_
 
@@ -58,7 +55,7 @@ T multi_exp(typename std::vector<T>::const_iterator vec_start,
             typename std::vector<T>::const_iterator vec_end,
             typename std::vector<FieldT>::const_iterator scalar_start,
             typename std::vector<FieldT>::const_iterator scalar_end,
-            const size_t chunks);
+            const std::size_t chunks);
 
 
 /**
@@ -72,7 +69,7 @@ T multi_exp_with_mixed_addition(typename std::vector<T>::const_iterator vec_star
                                 typename std::vector<T>::const_iterator vec_end,
                                 typename std::vector<FieldT>::const_iterator scalar_start,
                                 typename std::vector<FieldT>::const_iterator scalar_end,
-                                const size_t chunks);
+                                const std::size_t chunks);
 
 /**
  * A convenience function for calculating a pure inner product, where the
@@ -94,31 +91,31 @@ using window_table = std::vector<std::vector<T> >;
  * Compute window size for the given number of scalars.
  */
 template<typename T>
-size_t get_exp_window_size(const size_t num_scalars);
+std::size_t get_exp_window_size(const std::size_t num_scalars);
 
 /**
  * Compute table of window sizes.
  */
 template<typename T>
-window_table<T> get_window_table(const size_t scalar_size,
-                                 const size_t window,
+window_table<T> get_window_table(const std::size_t scalar_size,
+                                 const std::size_t window,
                                  const T &g);
 
 template<typename T, typename FieldT>
-T windowed_exp(const size_t scalar_size,
-               const size_t window,
+T windowed_exp(const std::size_t scalar_size,
+               const std::size_t window,
                const window_table<T> &powers_of_g,
                const FieldT &pow);
 
 template<typename T, typename FieldT>
-std::vector<T> batch_exp(const size_t scalar_size,
-                         const size_t window,
+std::vector<T> batch_exp(const std::size_t scalar_size,
+                         const std::size_t window,
                          const window_table<T> &table,
                          const std::vector<FieldT> &v);
 
 template<typename T, typename FieldT>
-std::vector<T> batch_exp_with_coeff(const size_t scalar_size,
-                                    const size_t window,
+std::vector<T> batch_exp_with_coeff(const std::size_t scalar_size,
+                                    const std::size_t window,
                                     const window_table<T> &table,
                                     const FieldT &coeff,
                                     const std::vector<FieldT> &v);

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -1,16 +1,13 @@
 /** @file
  *****************************************************************************
-
  Implementation of interfaces for multi-exponentiation routines.
 
  See multiexp.hpp .
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef MULTIEXP_TCC_
 #define MULTIEXP_TCC_
 
@@ -26,6 +23,8 @@
 #include <libff/common/utils.hpp>
 
 namespace libff {
+
+using std::size_t;
 
 template<mp_size_t n>
 class ordered_exponent {

--- a/libff/algebra/scalar_multiplication/multiexp_profile.cpp
+++ b/libff/algebra/scalar_multiplication/multiexp_profile.cpp
@@ -1,3 +1,13 @@
+/**
+ *****************************************************************************
+ Implementation of interfaces for multi-exponentiation routines.
+
+ See multiexp.hpp .
+ *****************************************************************************
+ * @author     This file is part of libff, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
 #include <cstdio>
 #include <vector>
 
@@ -7,6 +17,8 @@
 #include <libff/common/rng.hpp>
 
 using namespace libff;
+
+using std::size_t;
 
 template <typename GroupT>
 using run_result_t = std::pair<long long, std::vector<GroupT> >;

--- a/libff/algebra/scalar_multiplication/wnaf.hpp
+++ b/libff/algebra/scalar_multiplication/wnaf.hpp
@@ -1,14 +1,11 @@
 /** @file
  *****************************************************************************
-
  Declaration of interfaces for wNAF ("width-w Non-Adjacent Form") exponentiation routines.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef WNAF_HPP_
 #define WNAF_HPP_
 
@@ -22,19 +19,19 @@ namespace libff {
  * Find the wNAF representation of the given scalar relative to the given window size.
  */
 template<mp_size_t n>
-std::vector<long> find_wnaf(const size_t window_size, const bigint<n> &scalar);
+std::vector<long> find_wnaf(const std::size_t window_size, const bigint<n> &scalar);
 
 /**
  * In additive notation, use wNAF exponentiation (with the given window size) to compute scalar * base.
  */
 template<typename T, mp_size_t n>
-T fixed_window_wnaf_exp(const size_t window_size, const T &base, const bigint<n> &scalar);
+T fixed_window_wnaf_exp(const std::size_t window_size, const T &base, const bigint<n> &scalar);
 
 /**
  * In additive notation, use wNAF exponentiation (with the window size determined by T) to compute scalar * base.
  */
 template<typename T, mp_size_t n>
-T opt_window_wnaf_exp(const T &base, const bigint<n> &scalar, const size_t scalar_bits);
+T opt_window_wnaf_exp(const T &base, const bigint<n> &scalar, const std::size_t scalar_bits);
 
 } // libff
 

--- a/libff/algebra/scalar_multiplication/wnaf.tcc
+++ b/libff/algebra/scalar_multiplication/wnaf.tcc
@@ -1,22 +1,21 @@
 /** @file
  *****************************************************************************
-
  Implementation of interfaces for wNAF ("weighted Non-Adjacent Form") exponentiation routines.
 
  See wnaf.hpp .
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef WNAF_TCC_
 #define WNAF_TCC_
 
 #include <gmp.h>
 
 namespace libff {
+
+using std::size_t;
 
 template<mp_size_t n>
 std::vector<long> find_wnaf(const size_t window_size, const bigint<n> &scalar)

--- a/libff/common/default_types/ec_pp.hpp
+++ b/libff/common/default_types/ec_pp.hpp
@@ -1,15 +1,12 @@
 /** @file
  *****************************************************************************
-
  This file defines default_ec_pp based on the CURVE=... make flag, which selects
  which elliptic curve is used to implement group arithmetic and pairings.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef EC_PP_HPP_
 #define EC_PP_HPP_
 

--- a/libff/common/double.cpp
+++ b/libff/common/double.cpp
@@ -1,14 +1,11 @@
 /** @file
  *****************************************************************************
-
  Implementation of complex domain data type.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #include <cmath>
 #include <complex>
 
@@ -19,175 +16,177 @@
 
 namespace libff {
 
-  Double::Double()
-  {
+using std::size_t;
+
+Double::Double()
+{
     val = std::complex<double>(0, 0);
-  }
+}
 
-  Double::Double(double real)
-  {
+Double::Double(double real)
+{
     val = std::complex<double>(real, 0);
-  }
+}
 
-  Double::Double(double real, double imag)
-  {
+Double::Double(double real, double imag)
+{
     val = std::complex<double>(real, imag);
-  }
+}
 
-  Double::Double(std::complex<double> num)
-  {
+Double::Double(std::complex<double> num)
+{
     val = num;
-  }
+}
 
-  unsigned Double::add_cnt = 0;
-  unsigned Double::sub_cnt = 0;
-  unsigned Double::mul_cnt = 0;
-  unsigned Double::inv_cnt = 0;
+unsigned Double::add_cnt = 0;
+unsigned Double::sub_cnt = 0;
+unsigned Double::mul_cnt = 0;
+unsigned Double::inv_cnt = 0;
 
-  Double Double::operator+(const Double &other) const
-  {
+Double Double::operator+(const Double &other) const
+{
 #ifdef PROFILE_OP_COUNTS
     ++add_cnt;
 #endif
 
     return Double(val + other.val);
-  }
+}
 
-  Double Double::operator-(const Double &other) const
-  {
+Double Double::operator-(const Double &other) const
+{
 #ifdef PROFILE_OP_COUNTS
     ++sub_cnt;
 #endif
 
     return Double(val - other.val);
-  }
+}
 
-  Double Double::operator*(const Double &other) const
-  {
+Double Double::operator*(const Double &other) const
+{
 #ifdef PROFILE_OP_COUNTS
     ++mul_cnt;
 #endif
 
     return Double(val * other.val);
-  }
+}
 
-  Double Double::operator-() const
-  {
+Double Double::operator-() const
+{
     if (val.imag() == 0) return Double(-val.real());
 
     return Double(-val.real(), -val.imag());
-  }
+}
 
-  Double& Double::operator+=(const Double &other)
-  {
+Double& Double::operator+=(const Double &other)
+{
 #ifdef PROFILE_OP_COUNTS
     ++add_cnt;
 #endif
 
     this->val = std::complex<double>(val + other.val);
     return *this;
-  }
+}
 
-  Double& Double::operator-=(const Double &other)
-  {
+Double& Double::operator-=(const Double &other)
+{
 #ifdef PROFILE_OP_COUNTS
     ++sub_cnt;
 #endif
 
     this->val = std::complex<double>(val - other.val);
     return *this;
-  }
+}
 
-  Double& Double::operator*=(const Double &other)
-  {
+Double& Double::operator*=(const Double &other)
+{
 #ifdef PROFILE_OP_COUNTS
     ++mul_cnt;
 #endif
 
     this->val *= std::complex<double>(other.val);
     return *this;
-  }
+}
 
-  bool Double::operator==(const Double &other) const
-  {
+bool Double::operator==(const Double &other) const
+{
     return (std::abs(val.real() - other.val.real()) < 0.000001)
         && (std::abs(val.imag() - other.val.imag()) < 0.000001);
-  }
+}
 
-  bool Double::operator!=(const Double &other) const
-  {
+bool Double::operator!=(const Double &other) const
+{
     return Double(val) == other ? 0 : 1;
-  }
+}
 
-  bool Double::operator<(const Double &other) const
-  {
+bool Double::operator<(const Double &other) const
+{
     return (val.real() < other.val.real());
-  }
+}
 
-  bool Double::operator>(const Double &other) const
-  {
+bool Double::operator>(const Double &other) const
+{
     return (val.real() > other.val.real());
-  }
+}
 
-  Double Double::operator^(const libff::bigint<1> power) const
-  {
+Double Double::operator^(const libff::bigint<1> power) const
+{
     return Double(pow(val, power.as_ulong()));
-  }
+}
 
-  Double Double::operator^(const size_t power) const
-  {
+Double Double::operator^(const size_t power) const
+{
     return Double(pow(val, power));
-  }
+}
 
-  Double Double::inverse() const
-  {
+Double Double::inverse() const
+{
 #ifdef PROFILE_OP_COUNTS
     ++inv_cnt;
 #endif
 
     return Double(std::complex<double>(1) / val);
-  }
+}
 
-  libff::bigint<1> Double::as_bigint() const
-  {
+libff::bigint<1> Double::as_bigint() const
+{
     return libff::bigint<1>(val.real());
-  }
+}
 
-  unsigned long Double::as_ulong() const
-  {
+unsigned long Double::as_ulong() const
+{
     return round(val.real());
-  }
+}
 
-  Double Double::squared() const
-  {
+Double Double::squared() const
+{
     return Double(val * val);
-  }
+}
 
-  Double Double::one()
-  {
+Double Double::one()
+{
     return Double(1);
-  }
+}
 
-  Double Double::zero()
-  {
+Double Double::zero()
+{
     return Double(0);
-  }
+}
 
-  Double Double::random_element()
-  {
+Double Double::random_element()
+{
     return Double(std::rand() % 1001);
-  }
+}
 
-  Double Double::geometric_generator()
-  {
+Double Double::geometric_generator()
+{
     return Double(2);
-  }
+}
 
-  Double Double::arithmetic_generator()
-  {
+Double Double::arithmetic_generator()
+{
     return Double(1);
-  }
+}
 
-  Double Double::multiplicative_generator = Double(2);
+Double Double::multiplicative_generator = Double(2);
 
 } // libff

--- a/libff/common/double.hpp
+++ b/libff/common/double.hpp
@@ -1,14 +1,11 @@
 /** @file
  *****************************************************************************
-
  Declaration of complex domain data type.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef DOUBLE_HPP_
 #define DOUBLE_HPP_
 
@@ -18,59 +15,60 @@
 
 namespace libff {
 
-  const double PI = 3.141592653589793238460264338328L;
+const double PI = 3.141592653589793238460264338328L;
 
-  class Double 
-  {
-    public:
-      std::complex<double> val;
+class Double 
+{
+public:
+    std::complex<double> val;
 
-      Double();
+    Double();
 
-      Double(double real);
+    Double(double real);
 
-      Double(double real, double imag);
+    Double(double real, double imag);
 
-      Double(std::complex<double> num);
+    Double(std::complex<double> num);
 
-      static unsigned add_cnt;
-      static unsigned sub_cnt;
-      static unsigned mul_cnt;
-      static unsigned inv_cnt;
+    static unsigned add_cnt;
+    static unsigned sub_cnt;
+    static unsigned mul_cnt;
+    static unsigned inv_cnt;
 
-      Double operator+(const Double &other) const;
-      Double operator-(const Double &other) const;
-      Double operator*(const Double &other) const;
-      Double operator-() const;
+    Double operator+(const Double &other) const;
+    Double operator-(const Double &other) const;
+    Double operator*(const Double &other) const;
+    Double operator-() const;
 
-      Double& operator+=(const Double &other);
-      Double& operator-=(const Double &other);
-      Double& operator*=(const Double &other);
+    Double& operator+=(const Double &other);
+    Double& operator-=(const Double &other);
+    Double& operator*=(const Double &other);
 
-      bool operator==(const Double &other) const;
-      bool operator!=(const Double &other) const;
+    bool operator==(const Double &other) const;
+    bool operator!=(const Double &other) const;
 
-      bool operator<(const Double &other) const;
-      bool operator>(const Double &other) const;
+    bool operator<(const Double &other) const;
+    bool operator>(const Double &other) const;
 
-      Double operator^(const libff::bigint<1> power) const;
-      Double operator^(const size_t power) const;
+    Double operator^(const libff::bigint<1> power) const;
+    Double operator^(const std::size_t power) const;
 
-      libff::bigint<1> as_bigint() const;
-      unsigned long as_ulong() const;
-      Double inverse() const;
-      Double squared() const;
+    libff::bigint<1> as_bigint() const;
+    unsigned long as_ulong() const;
+    Double inverse() const;
+    Double squared() const;
 
-      static Double one();
-      static Double zero();
-      static Double random_element();
-      static Double geometric_generator();
-      static Double arithmetic_generator();
+    static Double one();
+    static Double zero();
+    static Double random_element();
+    static Double geometric_generator();
+    static Double arithmetic_generator();
 
-      static Double multiplicative_generator;
-      static Double root_of_unity; // See get_root_of_unity() in field_utils
-      static size_t s;
-  };
+    static Double multiplicative_generator;
+    static Double root_of_unity; // See get_root_of_unity() in field_utils
+    static std::size_t s;
+};
+
 } // libff
 
 #endif // DOUBLE_HPP_

--- a/libff/common/profiling.cpp
+++ b/libff/common/profiling.cpp
@@ -1,16 +1,13 @@
 /** @file
  *****************************************************************************
-
  Implementation of functions for profiling code blocks.
 
  See profiling.hpp .
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #include <cassert>
 #include <chrono>
 #include <cstdio>
@@ -28,6 +25,8 @@
 #endif
 
 namespace libff {
+
+using std::size_t;
 
 long long get_nsec_time()
 {

--- a/libff/common/profiling.hpp
+++ b/libff/common/profiling.hpp
@@ -1,16 +1,13 @@
 /** @file
  *****************************************************************************
-
  Declaration of functions for profiling code blocks.
 
  Reports time, operation counts, memory usage, and others.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef PROFILING_HPP_
 #define PROFILING_HPP_
 
@@ -30,7 +27,7 @@ void print_indent();
 
 extern bool inhibit_profiling_info;
 extern bool inhibit_profiling_counters;
-extern std::map<std::string, size_t> invocation_counts;
+extern std::map<std::string, std::size_t> invocation_counts;
 extern std::map<std::string, long long> last_times;
 extern std::map<std::string, long long> cumulative_times;
 

--- a/libff/common/rng.hpp
+++ b/libff/common/rng.hpp
@@ -1,14 +1,11 @@
 /** @file
  *****************************************************************************
-
  Declaration of functions for generating randomness.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef RNG_HPP_
 #define RNG_HPP_
 

--- a/libff/common/rng.tcc
+++ b/libff/common/rng.tcc
@@ -1,16 +1,13 @@
 /** @file
  *****************************************************************************
-
  Implementation of functions for generating randomness.
 
  See rng.hpp .
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef RNG_TCC_
 #define RNG_TCC_
 
@@ -22,6 +19,8 @@
 #include <libff/common/utils.hpp>
 
 namespace libff {
+
+using std::size_t;
 
 template<typename FieldT>
 FieldT SHA512_rng(const uint64_t idx)

--- a/libff/common/serialization.hpp
+++ b/libff/common/serialization.hpp
@@ -1,14 +1,11 @@
 /** @file
  *****************************************************************************
-
  Declaration of serialization routines and constants.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef SERIALIZATION_HPP_
 #define SERIALIZATION_HPP_
 

--- a/libff/common/serialization.tcc
+++ b/libff/common/serialization.tcc
@@ -1,16 +1,13 @@
 /** @file
  *****************************************************************************
-
  Implementation of serialization routines.
 
  See serialization.hpp .
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef SERIALIZATION_TCC_
 #define SERIALIZATION_TCC_
 
@@ -20,6 +17,8 @@
 #include <libff/common/utils.hpp>
 
 namespace libff {
+
+using std::size_t;
 
 inline void consume_newline(std::istream &in)
 {

--- a/libff/common/template_utils.hpp
+++ b/libff/common/template_utils.hpp
@@ -1,14 +1,11 @@
 /** @file
  *****************************************************************************
-
  Declaration of functions for supporting the use of templates.
-
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef TEMPLATE_UTILS_HPP_
 #define TEMPLATE_UTILS_HPP_
 

--- a/libff/common/utils.cpp
+++ b/libff/common/utils.cpp
@@ -1,12 +1,11 @@
 /** @file
  *****************************************************************************
- Implementation of misc math and serialization utility functions
+ Implementation of misc math and serialization utility functions.
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #include <algorithm>
 #include <cassert>
 #include <cstdarg>
@@ -15,6 +14,8 @@
 #include <libff/common/utils.hpp>
 
 namespace libff {
+
+using std::size_t;
 
 /**
  * Round n to the next power of two.
@@ -135,4 +136,5 @@ void deserialize_bit_vector(std::istream &in, bit_vector &v)
         v[i] = b;
     }
 }
+
 } // libff

--- a/libff/common/utils.hpp
+++ b/libff/common/utils.hpp
@@ -1,12 +1,11 @@
 /** @file
  *****************************************************************************
- Declaration of misc math and serialization utility functions
+ Declaration of misc math and serialization utility functions.
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef UTILS_HPP_
 #define UTILS_HPP_
 
@@ -20,18 +19,18 @@ namespace libff {
 
 typedef std::vector<bool> bit_vector;
 
-size_t get_power_of_two(size_t n);
+std::size_t get_power_of_two(std::size_t n);
 
 /// returns ceil(log2(n)), so 1ul<<log2(n) is the smallest power of 2, that is not less than n
-size_t log2(size_t n);
+std::size_t log2(std::size_t n);
 
-inline size_t exp2(size_t k) { return size_t(1) << k; }
+inline std::size_t exp2(std::size_t k) { return std::size_t(1) << k; }
 
-size_t to_twos_complement(int i, size_t w);
-int from_twos_complement(size_t i, size_t w);
+std::size_t to_twos_complement(int i, std::size_t w);
+int from_twos_complement(std::size_t i, std::size_t w);
 
-size_t bitreverse(size_t n, const size_t l);
-bit_vector int_list_to_bits(const std::initializer_list<unsigned long> &l, const size_t wordsize);
+std::size_t bitreverse(std::size_t n, const std::size_t l);
+bit_vector int_list_to_bits(const std::initializer_list<unsigned long> &l, const std::size_t wordsize);
 /* throws error if y = 0 */
 long long div_ceil(long long x, long long y);
 
@@ -53,7 +52,7 @@ void serialize_bit_vector(std::ostream &out, const bit_vector &v);
 void deserialize_bit_vector(std::istream &in, bit_vector &v);
 
 template<typename T>
-size_t ceil_size_in_bits(const std::vector<T> &v);
+std::size_t ceil_size_in_bits(const std::vector<T> &v);
 
 /**
  * Returns a random element of T that is not zero or one.

--- a/libff/common/utils.tcc
+++ b/libff/common/utils.tcc
@@ -1,16 +1,17 @@
 /** @file
  *****************************************************************************
- Implementation of templatized utility functions
+ Implementation of templatized utility functions.
  *****************************************************************************
  * @author     This file is part of libff, developed by SCIPR Lab
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-
 #ifndef UTILS_TCC_
 #define UTILS_TCC_
 
 namespace libff {
+
+using std::size_t;
 
 template<typename T>
 size_t ceil_size_in_bits(const std::vector<T> &v)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

After most code has been changed to use `std::size_t`, this PR takes care of the last files that still do not, `common/` and `algebra/scalar_multiplication/`. It also adjust some formatting in these files to be consistent with other parts of the repo.

closes: N/A

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [√] Targeted PR against correct branch (develop)
- [√] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [√] Wrote unit tests
- [√] Updated relevant documentation in the code
- [√] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [√] Re-reviewed `Files changed` in the Github PR explorer
