### PR TITLE
Changed static member function that was manipulating non-static members

### DIFF
--- a/libff/algebra/curves/edwards/edwards_pairing.cpp
+++ b/libff/algebra/curves/edwards/edwards_pairing.cpp
@@ -238,18 +238,18 @@ struct extended_edwards_G1_projective {
     edwards_Fq T;
 
     void print() const
-        {
-            printf("extended edwards_G1 projective X/Y/Z/T:\n");
-            X.print();
-            Y.print();
-            Z.print();
-            T.print();
-        }
+    {
+        printf("extended edwards_G1 projective X/Y/Z/T:\n");
+        X.print();
+        Y.print();
+        Z.print();
+        T.print();
+    }
 
-    static void test_invariant()
-        {
-            assert(T*Z == X*Y);
-        }
+    void test_invariant()
+    {
+        assert(T*Z == X*Y);
+    }
 };
 
 void doubling_step_for_miller_loop(extended_edwards_G1_projective &current,
@@ -464,7 +464,7 @@ struct extended_edwards_G2_projective {
             T.print();
         }
 
-    static void test_invariant()
+    void test_invariant()
         {
             assert(T*Z == X*Y);
         }

--- a/libff/algebra/curves/mnt/mnt4/mnt4_pairing.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_pairing.cpp
@@ -403,7 +403,7 @@ struct extended_mnt4_G2_projective {
         T.print();
     }
 
-    static void test_invariant()
+    void test_invariant()
     {
         assert(T == Z.squared());
     }

--- a/libff/algebra/curves/mnt/mnt6/mnt6_pairing.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_pairing.cpp
@@ -409,7 +409,7 @@ struct extended_mnt6_G2_projective {
         T.print();
     }
 
-    static void test_invariant()
+    void test_invariant()
     {
         assert(T == Z.squared());
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The current state of develop does not compile in `DEBUG` mode because a static member function manipulates non-static members causing a compilation error.

Here is the log:
```console
~/D/s/l/build ❯❯❯ make
[  6%] Built target zm
Scanning dependencies of target ff
[  8%] Building CXX object libff/CMakeFiles/ff.dir/algebra/curves/edwards/edwards_pairing.cpp.o
<path-to-libff>/scipr-lab/libff/libff/algebra/curves/edwards/edwards_pairing.cpp:251:20: fatal error: invalid use of member 'T' in static member function
            assert(T*Z == X*Y);
                   ^
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
1 error generated.
libff/CMakeFiles/ff.dir/build.make:290: recipe for target 'libff/CMakeFiles/ff.dir/algebra/curves/edwards/edwards_pairing.cpp.o' failed
make[2]: *** [libff/CMakeFiles/ff.dir/algebra/curves/edwards/edwards_pairing.cpp.o] Error 1
CMakeFiles/Makefile2:755: recipe for target 'libff/CMakeFiles/ff.dir/all' failed
make[1]: *** [libff/CMakeFiles/ff.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2
```

Here are the problematic lines: https://github.com/scipr-lab/libff/blob/develop/libff/algebra/curves/edwards/edwards_pairing.cpp#L452-L471 (same for mnt4/mnt6)
The error is triggered because of  https://github.com/scipr-lab/libff/blob/develop/libff/algebra/curves/edwards/edwards_pairing.cpp#L505-L507 which is added to the code when we compile in debug mode only.

As it clearly seems that this invariant check function should not be a static one (it needs an instance to be called upon), I removed the `static` keyword.
The compilation now passes in `DEBUG` mode

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (develop)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
